### PR TITLE
fix: send full Instagram carousels beyond Telegram batch limit

### DIFF
--- a/services/media/resolver.py
+++ b/services/media/resolver.py
@@ -18,7 +18,7 @@ async def resolve_cached_media_items(
     download_item: Callable[[int, T, str], Awaitable[Any | None]],
     metrics_label: str,
     error_label: str,
-    limit: int = 10,
+    limit: int | None = None,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     media_items: list[dict[str, Any]] = []
     downloaded_paths: list[str] = []
@@ -51,9 +51,11 @@ async def resolve_cached_media_items(
             "cached": False,
         }
 
+    items_to_resolve = items if limit is None else items[:limit]
+
     tasks = [
         asyncio.create_task(_resolve_item(index, item))
-        for index, item in enumerate(items[:limit])
+        for index, item in enumerate(items_to_resolve)
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/tests/test_instagram_handler.py
+++ b/tests/test_instagram_handler.py
@@ -262,6 +262,66 @@ async def test_instagram_media_group_replies_only_on_first_sent_message(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_instagram_media_group_sends_all_items_when_carousel_exceeds_ten(monkeypatch):
+    status_message = SimpleNamespace(delete=AsyncMock())
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=1),
+        chat=SimpleNamespace(id=10, type="private"),
+        message_id=20,
+        answer=AsyncMock(return_value=status_message),
+        answer_media_group=AsyncMock(
+            side_effect=[
+                [SimpleNamespace(photo=[SimpleNamespace(file_id=f"sent-photo-{index}")]) for index in range(10)],
+                [SimpleNamespace(photo=[SimpleNamespace(file_id=f"sent-photo-{10 + index}")]) for index in range(2)],
+            ]
+        ),
+        answer_photo=AsyncMock(return_value=SimpleNamespace(photo=[SimpleNamespace(file_id="sent-photo-12")])),
+        answer_video=AsyncMock(),
+        reply_video=AsyncMock(),
+        reply_photo=AsyncMock(),
+    )
+    data = instagram.InstagramVideo(
+        id="ig-13",
+        description="caption",
+        author="author",
+        media_list=[
+            instagram.InstagramMedia(url=f"https://cdn.example.com/{index}.jpg", type="photo")
+            for index in range(13)
+        ],
+    )
+
+    monkeypatch.setattr(instagram, "send_analytics", AsyncMock())
+    monkeypatch.setattr(instagram, "send_chat_action_if_needed", AsyncMock())
+    monkeypatch.setattr(instagram, "safe_edit_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(instagram, "safe_delete_message", AsyncMock())
+    monkeypatch.setattr(instagram, "maybe_delete_user_message", AsyncMock())
+    monkeypatch.setattr(instagram.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(instagram.db, "add_file", AsyncMock())
+    monkeypatch.setattr(
+        instagram.inst_service,
+        "download_media",
+        AsyncMock(side_effect=[SimpleNamespace(path=f"/tmp/{index}.jpg") for index in range(13)]),
+    )
+
+    result = await instagram.process_instagram_media_group(
+        message,
+        data,
+        "https://instagram.com/p/abc/",
+        "https://t.me/maxloadbot",
+        {"captions": "on", "delete_message": "off", "info_buttons": "off", "url_button": "off", "audio_button": "off"},
+        None,
+    )
+
+    assert result is True
+    assert instagram.inst_service.download_media.await_count == 13
+    assert message.answer_media_group.await_count == 2
+    assert message.answer_media_group.await_args_list[0].kwargs["reply_to_message_id"] == 20
+    assert "reply_to_message_id" not in message.answer_media_group.await_args_list[1].kwargs
+    assert message.answer_photo.await_args.kwargs["photo"].path == "/tmp/12.jpg"
+    assert message.reply_photo.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_inline_instagram_query_returns_album_deeplink_for_multi_video_post(monkeypatch):
     settings = {
         "captions": "on",

--- a/tests/test_media_delivery.py
+++ b/tests/test_media_delivery.py
@@ -87,3 +87,49 @@ async def test_send_cached_media_entries_supports_url_based_photo_entries():
     assert message.answer_media_group.await_args.kwargs["reply_to_message_id"] == 11
     assert message.answer_photo.await_args.kwargs["photo"] == "https://cdn.example.com/2.jpg"
     db_service.add_file.assert_awaited_once_with("album#1", "last-photo-id", "photo")
+
+
+@pytest.mark.asyncio
+async def test_send_cached_media_entries_splits_large_albums_into_multiple_batches():
+    message = SimpleNamespace(
+        message_id=99,
+        answer_media_group=AsyncMock(
+            side_effect=[
+                [SimpleNamespace(photo=[SimpleNamespace(file_id=f"batch1-photo-{index}")]) for index in range(10)],
+                [SimpleNamespace(photo=[SimpleNamespace(file_id=f"batch2-photo-{index}")]) for index in range(2)],
+            ]
+        ),
+        answer_photo=AsyncMock(return_value=SimpleNamespace(photo=[SimpleNamespace(file_id="last-photo-id")])),
+        reply_photo=AsyncMock(),
+        answer_video=AsyncMock(),
+        reply_video=AsyncMock(),
+    )
+    db_service = SimpleNamespace(add_file=AsyncMock())
+    entries = [
+        {
+            "kind": "photo",
+            "cache_key": f"album#{index}",
+            "file_id": None,
+            "path": f"/tmp/{index}.jpg",
+            "cached": False,
+        }
+        for index in range(13)
+    ]
+
+    await send_cached_media_entries(
+        message,
+        entries,
+        db_service=db_service,
+        caption="caption",
+        reply_markup=None,
+    )
+
+    assert message.answer_media_group.await_count == 2
+    first_batch_kwargs = message.answer_media_group.await_args_list[0].kwargs
+    second_batch_kwargs = message.answer_media_group.await_args_list[1].kwargs
+    assert first_batch_kwargs["reply_to_message_id"] == 99
+    assert "reply_to_message_id" not in second_batch_kwargs
+    assert len(first_batch_kwargs["media"]) == 10
+    assert len(second_batch_kwargs["media"]) == 2
+    assert message.answer_photo.await_args.kwargs["photo"].path == "/tmp/12.jpg"
+    assert db_service.add_file.await_count == 13

--- a/tests/test_media_resolver.py
+++ b/tests/test_media_resolver.py
@@ -31,3 +31,29 @@ async def test_resolve_cached_media_items_reuses_cache_and_tracks_download_paths
     assert media_items[0]["file_id"] == "cached-photo-id"
     assert downloaded_paths == ["/tmp/clip.mp4"]
     log_metrics.assert_called_once_with("test_media", metrics)
+
+
+@pytest.mark.asyncio
+async def test_resolve_cached_media_items_processes_all_items_by_default(monkeypatch):
+    items = [SimpleNamespace(type="photo") for _ in range(13)]
+    db_service = SimpleNamespace(get_file_id=AsyncMock(return_value=None))
+    log_metrics = Mock()
+    monkeypatch.setattr(media_resolver, "log_download_metrics", log_metrics)
+
+    async def download_item(index, _item, _kind):
+        return SimpleNamespace(path=f"/tmp/item-{index}.jpg")
+
+    media_items, downloaded_paths = await media_resolver.resolve_cached_media_items(
+        items,
+        db_service=db_service,
+        kind_getter=lambda item: item.type,
+        build_cache_key=lambda index, _item, kind: f"post#{index}:{kind}",
+        download_item=download_item,
+        metrics_label="test_media",
+        error_label="Resolver",
+    )
+
+    assert len(media_items) == 13
+    assert [item["cache_key"] for item in media_items] == [f"post#{index}:photo" for index in range(13)]
+    assert downloaded_paths == [f"/tmp/item-{index}.jpg" for index in range(13)]
+    assert log_metrics.call_count == 13


### PR DESCRIPTION
## Summary
- remove the default 10-item resolver cap so Instagram carousels keep all media entries
- rely on the shared media delivery batching to split Telegram albums into 10-item chunks
- add regression coverage for resolver, delivery batching, and the Instagram handler flow

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_media_resolver.py tests/test_media_delivery.py tests/test_media_orchestration.py tests/test_instagram_handler.py tests/test_pinterest_handler.py

Closes #44