### PR TITLE
feat: add local PostgreSQL with automated backup/restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ code_review.md
 CLAUDE.md
 .agents/
 .mimocode/
+backups/

--- a/Dockerfile.backup
+++ b/Dockerfile.backup
@@ -1,0 +1,12 @@
+FROM python:3.14-alpine
+
+RUN apk add --no-cache bash curl postgresql17-client && \
+    pip install --no-cache-dir b2
+
+COPY scripts/backup-service/entrypoint.sh /entrypoint.sh
+COPY scripts/backup-service/backup.sh /backup.sh
+COPY scripts/backup-service/restore.sh /restore.sh
+
+RUN chmod +x /entrypoint.sh /backup.sh /restore.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - ./cookies:/app/cookies
     env_file: .env
     container_name: downloader-bot
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     restart: on-failure:5
     healthcheck:
       test: ["CMD", "python", "-c", "import asyncio; asyncio.run(asyncio.wait_for(asyncio.sleep(0.1), timeout=5))"]
@@ -27,6 +30,70 @@ services:
           cpus: '0.5'
           memory: 256M
 
+  postgres:
+    image: postgres:17-alpine
+    container_name: downloader-postgres
+    environment:
+      POSTGRES_DB: downloader_bot
+      POSTGRES_USER: bot_user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bot_user -d downloader_bot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  db-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.backup
+    container_name: downloader-db-init
+    environment:
+      RESTORE_HOST: postgres
+      RESTORE_DB: downloader_bot
+      RESTORE_USER: bot_user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      RESTORE_REPOSITORY: ${RESTIC_REPOSITORY:-}
+      RESTORE_PASSWORD: ${RESTIC_PASSWORD:-}
+      B2_KEY_ID: ${B2_KEY_ID:-}
+      B2_APP_KEY: ${B2_APP_KEY:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - postgres_backups:/backups
+    restart: "no"
+    entrypoint: ["/restore.sh"]
+
+  backup:
+    build:
+      context: .
+      dockerfile: Dockerfile.backup
+    container_name: downloader-backup
+    environment:
+      BACKUP_HOST: postgres
+      BACKUP_DB: downloader_bot
+      BACKUP_USER: bot_user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      RESTIC_REPOSITORY: ${RESTIC_REPOSITORY:-}
+      RESTIC_PASSWORD: ${RESTIC_PASSWORD:-}
+      B2_KEY_ID: ${B2_KEY_ID:-}
+      B2_APP_KEY: ${B2_APP_KEY:-}
+      BACKUP_CRON: ${BACKUP_CRON:-0 3 * * *}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - postgres_backups:/backups
+    restart: unless-stopped
+
 volumes:
   downloader_downloads:
   downloader_log:
+  postgres_data:
+  postgres_backups:

--- a/scripts/.env.backup.example
+++ b/scripts/.env.backup.example
@@ -1,0 +1,10 @@
+# Backup Configuration
+# Copy this to .env.backup and fill in your values
+
+# Backblaze B2 credentials
+B2_ACCOUNT_ID=your_key_id
+B2_ACCOUNT_KEY=your_app_key
+
+# Restic repository (Backblaze B2)
+RESTIC_REPOSITORY=s3:s3.us-east-005.backblazeb2.com/your-bucket-name
+RESTIC_PASSWORD_FILE=/Users/mak5er/Dev/python/Downloader-Bot/scripts/.restic_password

--- a/scripts/backup-service/backup.sh
+++ b/scripts/backup-service/backup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+B2_BUCKET="${B2_BUCKET:-maxload}"
+B2_KEY_ID="${B2_KEY_ID:-}"
+B2_APP_KEY="${B2_APP_KEY:-}"
+BACKUP_HOST="${BACKUP_HOST:-postgres}"
+BACKUP_DB="${BACKUP_DB:-downloader_bot}"
+BACKUP_USER="${BACKUP_USER:-bot_user}"
+BACKUP_PASS="${BACKUP_PASS:-${POSTGRES_PASSWORD:-changeme}}"
+export PGPASSWORD="$BACKUP_PASS"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUMP_FILE="/tmp/db_backup_${TIMESTAMP}.dump"
+LOG_PREFIX="[backup ${TIMESTAMP}]"
+
+log() { echo "${LOG_PREFIX} $*"; }
+
+cleanup() { rm -f "$DUMP_FILE"; }
+trap cleanup EXIT
+
+log "Starting database dump..."
+pg_dump -Fc -h "$BACKUP_HOST" -U "$BACKUP_USER" "$BACKUP_DB" > "$DUMP_FILE"
+DUMP_SIZE=$(ls -lh "$DUMP_FILE" | awk '{print $5}')
+log "Dump completed: ${DUMP_SIZE}"
+
+# Always save locally for restore
+LOCAL_FILE="/backups/db_backup_${TIMESTAMP}.dump"
+cp "$DUMP_FILE" "$LOCAL_FILE"
+log "Saved to ${LOCAL_FILE}"
+
+# Keep only last 7 local backups
+ls -t /backups/db_backup_*.dump 2>/dev/null | tail -n +8 | xargs -r rm -f
+
+# Upload to B2 if configured
+if [ -n "$B2_KEY_ID" ] && [ -n "$B2_APP_KEY" ] && [ -n "$B2_BUCKET" ]; then
+    log "Uploading to B2 bucket: ${B2_BUCKET}..."
+    b2 upload-file "$B2_BUCKET" "$DUMP_FILE" "backups/db_backup_${TIMESTAMP}.dump" 2>&1
+    log "Upload completed"
+
+    # Delete old backups from B2 (keep last 30)
+    log "Cleaning old B2 backups..."
+    EXISTING=$(b2 ls --long "b2://${B2_BUCKET}/backups/" 2>/dev/null | wc -l)
+    if [ "$EXISTING" -gt 30 ]; then
+        b2 ls --long "b2://${B2_BUCKET}/backups/" 2>/dev/null | head -n $((EXISTING - 30)) | awk '{print $1}' | while read -r file_id; do
+            b2 delete-file-version "$file_id" 2>/dev/null || true
+        done
+        log "Cleaned old backups from B2"
+    fi
+else
+    log "B2 not configured, local backup only"
+fi
+
+log "Backup finished"

--- a/scripts/backup-service/entrypoint.sh
+++ b/scripts/backup-service/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "[backup] Starting backup service..."
+
+B2_KEY_ID="${B2_KEY_ID:-}"
+B2_APP_KEY="${B2_APP_KEY:-}"
+BACKUP_CRON="${BACKUP_CRON:-0 3 * * *}"
+
+# Authorize B2 if credentials provided
+if [ -n "$B2_KEY_ID" ] && [ -n "$B2_APP_KEY" ]; then
+    echo "[backup] Authorizing B2..."
+    b2 authorize-account "$B2_KEY_ID" "$B2_APP_KEY"
+    echo "[backup] B2 authorized"
+else
+    echo "[backup] WARNING: B2 credentials not set, local backups only"
+fi
+
+# Create local backup directory
+mkdir -p /backups
+
+# Write cron schedule
+echo "${BACKUP_CRON} /backup.sh >> /var/log/backup.log 2>&1" > /etc/crontabs/root
+
+echo "[backup] Cron schedule: ${BACKUP_CRON}"
+echo "[backup] Starting cron daemon..."
+exec crond -f -l 2

--- a/scripts/backup-service/init-repo.sh
+++ b/scripts/backup-service/init-repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+export RESTIC_REPOSITORY="${RESTIC_REPOSITORY:-}"
+export RESTIC_PASSWORD="${RESTIC_PASSWORD:-}"
+export AWS_ACCESS_KEY_ID="${B2_KEY_ID:-}"
+export AWS_SECRET_ACCESS_KEY="${B2_APP_KEY:-}"
+
+if [ -z "$RESTIC_REPOSITORY" ] || [ -z "$RESTIC_PASSWORD" ]; then
+    echo "[init] RESTIC_REPOSITORY or RESTIC_PASSWORD not set, skipping init"
+    exit 0
+fi
+
+if restic cat config 2>/dev/null; then
+    echo "[init] Repository already initialized"
+else
+    echo "[init] Initializing new restic repository..."
+    restic init 2>&1
+    echo "[init] Repository initialized successfully"
+fi

--- a/scripts/backup-service/restore.sh
+++ b/scripts/backup-service/restore.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+B2_BUCKET="${B2_BUCKET:-maxload}"
+B2_KEY_ID="${B2_KEY_ID:-}"
+B2_APP_KEY="${B2_APP_KEY:-}"
+RESTORE_HOST="${RESTORE_HOST:-postgres}"
+RESTORE_DB="${RESTORE_DB:-downloader_bot}"
+RESTORE_USER="${RESTORE_USER:-bot_user}"
+RESTORE_PASS="${RESTORE_PASS:-${POSTGRES_PASSWORD:-changeme}}"
+export PGPASSWORD="$RESTORE_PASS"
+LOG_PREFIX="[restore]"
+
+log() { echo "${LOG_PREFIX} $*"; }
+
+restore_from_dump() {
+    local dump_file="$1"
+    log "Dropping and recreating database..."
+    psql -h "$RESTORE_HOST" -U "$RESTORE_USER" -d postgres -c "DROP DATABASE IF EXISTS ${RESTORE_DB};"
+    psql -h "$RESTORE_HOST" -U "$RESTORE_USER" -d postgres -c "CREATE DATABASE ${RESTORE_DB} OWNER ${RESTORE_USER};"
+
+    log "Restoring from dump..."
+    pg_restore -h "$RESTORE_HOST" -U "$RESTORE_USER" -d "$RESTORE_DB" "$dump_file" 2>/dev/null || true
+
+    log "Fixing ownership and privileges..."
+    psql -h "$RESTORE_HOST" -U "$RESTORE_USER" -d "$RESTORE_DB" <<-'EOSQL'
+        DO $$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+                EXECUTE 'ALTER TABLE ' || quote_ident(r.tablename) || ' OWNER TO bot_user';
+            END LOOP;
+            FOR r IN SELECT sequencename FROM pg_sequences WHERE schemaname = 'public' LOOP
+                EXECUTE 'ALTER SEQUENCE ' || quote_ident(r.sequencename) || ' OWNER TO bot_user';
+            END LOOP;
+        END $$;
+        GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO bot_user;
+        GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO bot_user;
+EOSQL
+
+    log "Verifying restored data..."
+    psql -h "$RESTORE_HOST" -U "$RESTORE_USER" -d "$RESTORE_DB" -c "
+        SELECT 'users' AS t, COUNT(*) FROM users
+        UNION ALL SELECT 'files', COUNT(*) FROM downloaded_files
+        UNION ALL SELECT 'events', COUNT(*) FROM analytics_events
+        UNION ALL SELECT 'settings', COUNT(*) FROM settings;
+    "
+}
+
+# Check if database has tables
+TABLE_COUNT=$(psql -h "$RESTORE_HOST" -U "$RESTORE_USER" -d "$RESTORE_DB" -t -c \
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public';" 2>/dev/null || echo "0")
+TABLE_COUNT=$(echo "$TABLE_COUNT" | tr -d ' ')
+
+if [ "$TABLE_COUNT" -gt 2 ]; then
+    log "Database has ${TABLE_COUNT} tables — no restore needed"
+    exit 0
+fi
+
+log "Database is empty (${TABLE_COUNT} tables) — attempting restore..."
+
+# Try local dump first
+LATEST_DUMP=$(find /backups -name "*.dump" -type f 2>/dev/null | sort -r | head -1)
+if [ -n "$LATEST_DUMP" ]; then
+    log "Found local dump: ${LATEST_DUMP}"
+    restore_from_dump "$LATEST_DUMP"
+    log "Restore from local dump completed"
+    exit 0
+fi
+
+# Try B2
+if [ -n "$B2_KEY_ID" ] && [ -n "$B2_APP_KEY" ] && [ -n "$B2_BUCKET" ]; then
+    log "No local dump found, trying B2..."
+    b2 authorize-account "$B2_KEY_ID" "$B2_APP_KEY" 2>/dev/null || true
+    LATEST_B2=$(b2 ls --long "b2://${B2_BUCKET}/backups/" 2>/dev/null | tail -1 | awk '{print $1}')
+    if [ -n "$LATEST_B2" ]; then
+        b2 download-file-by-id "$LATEST_B2" > /tmp/latest_backup.dump 2>/dev/null
+        restore_from_dump "/tmp/latest_backup.dump"
+        rm -f /tmp/latest_backup.dump
+        log "Restore from B2 completed"
+        exit 0
+    fi
+fi
+
+log "WARNING: No backup found — starting with empty database"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_FILE="${PROJECT_DIR}/logs/backup.log"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUMP_FILE="/tmp/db_backup_${TIMESTAMP}.dump"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+cleanup() {
+    rm -f "$DUMP_FILE"
+}
+trap cleanup EXIT
+
+log "Starting backup..."
+
+# Dump database via Docker
+log "Dumping database..."
+docker exec downloader-postgres pg_dump -Fc -U bot_user downloader_bot > "$DUMP_FILE"
+
+DUMP_SIZE=$(ls -lh "$DUMP_FILE" | awk '{print $5}')
+log "Dump completed: $DUMP_SIZE"
+
+# Upload to restic (if configured)
+if [ -n "${RESTIC_REPOSITORY:-}" ] && [ -f "${RESTIC_PASSWORD_FILE:-/dev/null}" ]; then
+    log "Uploading to restic repository..."
+    export RESTIC_REPOSITORY RESTIC_PASSWORD_FILE
+    restic backup "$DUMP_FILE" --tag "db-backup" 2>&1 | tee -a "$LOG_FILE"
+    log "Restic upload completed"
+
+    # Prune old backups
+    log "Pruning old backups..."
+    restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune 2>&1 | tee -a "$LOG_FILE"
+    log "Prune completed"
+else
+    log "WARNING: RESTIC_REPOSITORY not configured, backup saved locally at $DUMP_FILE"
+    # Copy to project backups directory as fallback
+    BACKUP_DIR="${PROJECT_DIR}/backups"
+    mkdir -p "$BACKUP_DIR"
+    cp "$DUMP_FILE" "${BACKUP_DIR}/db_backup_${TIMESTAMP}.dump"
+    log "Backup saved to ${BACKUP_DIR}/db_backup_${TIMESTAMP}.dump"
+
+    # Keep only last 7 local backups
+    ls -t "${BACKUP_DIR}"/db_backup_*.dump 2>/dev/null | tail -n +8 | xargs -r rm -f
+fi
+
+log "Backup completed successfully"

--- a/scripts/cron-backup.sh
+++ b/scripts/cron-backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Wrapper script for cron - sources env and runs backup
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Load backup environment if exists
+if [ -f "${SCRIPT_DIR}/.env.backup" ]; then
+    set -a
+    source "${SCRIPT_DIR}/.env.backup"
+    set +a
+fi
+
+exec "${SCRIPT_DIR}/backup.sh"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_FILE="${PROJECT_DIR}/logs/restore.log"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# Determine backup source
+BACKUP_FILE="${1:-}"
+RESTORE_FROM_RESTIC="${2:-}"
+
+if [ -z "$BACKUP_FILE" ] && [ "$RESTORE_FROM_RESTIC" != "restic" ]; then
+    echo "Usage: $0 <backup_file.dump>"
+    echo "   or: $0 <restic_snapshot_id> restic"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/db_backup_20260620.dump"
+    echo "  $0 latest restic"
+    exit 1
+fi
+
+log "Starting restore..."
+
+if [ "$RESTORE_FROM_RESTIC" = "restic" ]; then
+    log "Restoring from restic snapshot: $BACKUP_FILE"
+    RESTORE_DIR="/tmp/restic_restore_$$"
+    mkdir -p "$RESTORE_DIR"
+
+    export RESTIC_REPOSITORY RESTIC_PASSWORD_FILE
+    restic restore "$BACKUP_FILE" --target "$RESTORE_DIR"
+    BACKUP_FILE=$(find "$RESTORE_DIR" -name "*.dump" -type f | head -1)
+
+    if [ -z "$BACKUP_FILE" ]; then
+        log "ERROR: No .dump file found in restic restore"
+        rm -rf "$RESTORE_DIR"
+        exit 1
+    fi
+    log "Restored dump from restic: $BACKUP_FILE"
+fi
+
+log "Restoring database from $BACKUP_FILE"
+
+# Stop the bot during restore
+log "Stopping bot..."
+docker compose -f "${PROJECT_DIR}/docker-compose.yml" stop downloader-bot
+
+# Drop and recreate database
+log "Recreating database..."
+docker exec downloader-postgres psql -U bot_user -d postgres -c "DROP DATABASE IF EXISTS downloader_bot;"
+docker exec downloader-postgres psql -U bot_user -d postgres -c "CREATE DATABASE downloader_bot OWNER bot_user;"
+
+# Restore
+log "Running pg_restore..."
+docker cp "$BACKUP_FILE" downloader-postgres:/tmp/backup.dump
+docker exec downloader-postgres pg_restore -U bot_user -d downloader_bot /tmp/backup.dump 2>&1 | tee -a "$LOG_FILE"
+docker exec downloader-postgres rm -f /tmp/backup.dump
+
+# Fix ownership (dynamic — works for any table)
+log "Fixing table ownership..."
+docker exec downloader-postgres psql -U bot_user -d downloader_bot -c "
+DO \$\$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+        EXECUTE 'ALTER TABLE ' || quote_ident(r.tablename) || ' OWNER TO bot_user';
+    END LOOP;
+    FOR r IN SELECT sequencename FROM pg_sequences WHERE schemaname = 'public' LOOP
+        EXECUTE 'ALTER SEQUENCE ' || quote_ident(r.sequencename) || ' OWNER TO bot_user';
+    END LOOP;
+END \$\$;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO bot_user;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO bot_user;
+"
+
+# Verify data
+log "Verifying restored data..."
+docker exec downloader-postgres psql -U bot_user -d downloader_bot -c "
+SELECT 'users' AS table_name, COUNT(*) AS count FROM users
+UNION ALL SELECT 'downloaded_files', COUNT(*) FROM downloaded_files
+UNION ALL SELECT 'analytics_events', COUNT(*) FROM analytics_events
+UNION ALL SELECT 'settings', COUNT(*) FROM settings;
+"
+
+# Start bot
+log "Starting bot..."
+docker compose -f "${PROJECT_DIR}/docker-compose.yml" start downloader-bot
+
+# Cleanup restore directory if used
+if [ "$RESTORE_FROM_RESTIC" = "restic" ]; then
+    rm -rf "$RESTORE_DIR"
+fi
+
+log "Restore completed successfully"


### PR DESCRIPTION
Add postgres, db-init, and backup services to docker-compose. Migrate database from Neon DB to self-hosted PostgreSQL 17.

- postgres:17-alpine with healthcheck and persistent volume
- db-init: auto-restore from local dump or Backblaze B2 on first start
- backup: scheduled pg_dump with B2 upload (daily at 3am)
- Host-side scripts: backup.sh, restore.sh, cron-backup.sh
- Fixed dynamic table ownership in restore (no hardcoded table names)
- Fixed pg_restore to use docker cp instead of stdin pipe