### PR TITLE
refactor: full-project audit — bug fixes, performance, deduplication

### DIFF
--- a/.github/workflows/yt-dlp-auto-bump.yml
+++ b/.github/workflows/yt-dlp-auto-bump.yml
@@ -9,6 +9,14 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  BOT_TOKEN: "123456:TESTTOKEN"
+  ADMIN_ID: "1"
+  CUSTOM_API_URL: "https://api.example.com"
+  CHANNEL_ID: "-1001234567890"
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/downloader_bot_test
+  PYTHONPATH: ${{ github.workspace }}
+
 jobs:
   check-yt-dlp:
     runs-on: ubuntu-latest
@@ -18,12 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest pytest-cov yt-dlp -r requirements.txt
+          python-version: '3.14'
 
       - name: Get latest yt-dlp version
         id: latest-ytdlp
@@ -42,6 +45,12 @@ jobs:
         run: |
           sed -i -E "s/yt-dlp\[default\]==[0-9.]+/yt-dlp[default]==${{ steps.latest-ytdlp.outputs.version }}/g" requirements.txt
           sed -i -E "s/yt-dlp==[0-9.]+/yt-dlp==${{ steps.latest-ytdlp.outputs.version }}/g" requirements.txt
+
+      - name: Install dependencies
+        if: steps.latest-ytdlp.outputs.version != steps.current-ytdlp.outputs.version
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
       - name: Run pytest baseline
         if: steps.latest-ytdlp.outputs.version != steps.current-ytdlp.outputs.version

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -21,6 +21,7 @@ from aiogram.types import BufferedInputFile
 
 import keyboards as kb
 import messages as bm
+import messages.admin_messages as bm_admin
 from app_context import bot, db
 from config import ADMINS_UID, OUTPUT_DIR
 from filters import IsBotAdmin
@@ -271,12 +272,16 @@ async def _deliver_mailing_message(user, *, sender_id: int, message_id: int) -> 
         )
         if user_status == "inactive":
             await db.set_active(user_id)
-    except Exception as error:
-        error_text = str(error)
-        if error_text == "Forbidden: bots can't send messages to bots":
+    except TelegramForbiddenError as error:
+        if "bots can't send messages to bots" in error.message:
             await db.delete_user(user_id)
-        if "blocked" in error_text or "Chat not found" in error_text:
+        elif "blocked" in error.message:
             await db.set_inactive(user_id)
+    except TelegramBadRequest as error:
+        if "chat not found" in error.message.lower():
+            await db.set_inactive(user_id)
+    except Exception as error:
+        logging.warning("Failed to deliver mailing message to %s: %s", user_id, error)
     finally:
         await asyncio.sleep(_ADMIN_THROTTLE_SECONDS)
 
@@ -286,10 +291,6 @@ class Mailing(StatesGroup):
 
 
 class Admin(StatesGroup):
-    add_joke = State()
-    control_user = State()
-    ban_reason = State()
-    feedback_answer = State()
     write_message = State()
     write_chat_id = State()
     write_chat_text = State()
@@ -418,9 +419,9 @@ async def _render_health_text(*, include_queue: bool = True, include_runtime_dow
     return "\n".join(lines)
 
 
-def _render_downloads_text(*, footer: str | None = None, include_cleanup_load: bool = True) -> str:
+async def _render_downloads_text(*, footer: str | None = None, include_cleanup_load: bool = True) -> str:
     queue_snapshot = get_download_queue().load_snapshot()
-    snapshot = _build_directory_snapshot(OUTPUT_DIR)
+    snapshot = await asyncio.to_thread(_build_directory_snapshot, OUTPUT_DIR)
     cleanup_ready = queue_snapshot.active_jobs == 0 and queue_snapshot.queued_jobs == 0
     lines = [
         "<b>Downloads Storage</b>",
@@ -451,9 +452,9 @@ async def _render_ops_text() -> str:
     return f"{health_text}\n\n{perf_text}"
 
 
-def _render_runtime_storage_text(*, footer: str | None = None) -> str:
+async def _render_runtime_storage_text(*, footer: str | None = None) -> str:
     session_text = _render_session_text()
-    downloads_text = _render_downloads_text(footer=footer, include_cleanup_load=False)
+    downloads_text = await _render_downloads_text(footer=footer, include_cleanup_load=False)
     return f"{session_text}\n\n{downloads_text}"
 
 
@@ -485,7 +486,7 @@ async def _cleanup_downloads_once() -> str:
         return bm.downloads_cleanup_blocked(queue_snapshot.active_jobs, queue_snapshot.queued_jobs)
     if not os.path.exists(OUTPUT_DIR):
         return f"The folder '{OUTPUT_DIR}' does not exist."
-    removed_files, skipped_recent_files, removed_dirs = _cleanup_download_tree()
+    removed_files, skipped_recent_files, removed_dirs = await asyncio.to_thread(_cleanup_download_tree)
     return bm.downloads_cleanup_finished(removed_files, removed_dirs, skipped_recent_files)
 
 
@@ -536,7 +537,7 @@ async def admin_runtime_storage(call: types.CallbackQuery):
     await call.answer()
     queue_snapshot = get_download_queue().load_snapshot()
     await call.message.edit_text(
-        text=_render_runtime_storage_text(),
+        text=await _render_runtime_storage_text(),
         reply_markup=kb.downloads_admin_keyboard(
             can_cleanup=queue_snapshot.active_jobs == 0 and queue_snapshot.queued_jobs == 0,
             refresh_callback="admin_runtime_storage",
@@ -588,7 +589,7 @@ async def admin_downloads(call: types.CallbackQuery):
     await call.answer()
     queue_snapshot = get_download_queue().load_snapshot()
     await call.message.edit_text(
-        text=_render_downloads_text(),
+        text=await _render_downloads_text(),
         reply_markup=kb.downloads_admin_keyboard(
             can_cleanup=queue_snapshot.active_jobs == 0 and queue_snapshot.queued_jobs == 0
         ),
@@ -604,7 +605,7 @@ async def admin_cleanup_downloads(call: types.CallbackQuery):
     await call.answer("Cleanup finished" if "finished" in status_text else "Cleanup skipped")
     queue_snapshot = get_download_queue().load_snapshot()
     await call.message.edit_text(
-        text=_render_runtime_storage_text(footer=status_text),
+        text=await _render_runtime_storage_text(footer=status_text),
         reply_markup=kb.downloads_admin_keyboard(
             can_cleanup=queue_snapshot.active_jobs == 0 and queue_snapshot.queued_jobs == 0,
             refresh_callback="admin_runtime_storage",
@@ -898,7 +899,7 @@ async def send_to_all_message(message: types.Message, state: FSMContext):
                                text=bm.start_mailing(),
                                reply_markup=types.ReplyKeyboardRemove())
 
-        users = await db.get_all_users_info()
+        users = [user for user in await db.get_all_users_info() if (user.status or "inactive") != "ban"]
         await _run_bounded(
             users,
             limit=_ADMIN_MAILING_CONCURRENCY,
@@ -956,7 +957,7 @@ async def write_message(message: types.Message, state: FSMContext):
 
     except Exception as e:
         logging.error(e)
-        await message.reply(bm.something_went_wrong(),
+        await message.reply(bm_admin.something_went_wrong(),
                             reply_markup=kb.return_back_to_admin_keyboard())
 
 

--- a/handlers/bot_profile_cache.py
+++ b/handlers/bot_profile_cache.py
@@ -13,6 +13,7 @@ _bot_avatar_path: Optional[str] = None
 _bot_username: Optional[str] = None
 _bot_id: Optional[int] = None
 _bot_identity_lock = asyncio.Lock()
+_bot_avatar_lock = asyncio.Lock()
 _AUDIO_THUMB_MAX_DIMENSION = 320
 _AUDIO_THUMB_MAX_BYTES = 200 * 1024
 _AUDIO_THUMB_PATH = Path("downloads") / "bot_audio_thumbnail.jpg"
@@ -71,26 +72,32 @@ async def get_bot_avatar_thumbnail(bot: Bot) -> Optional[FSInputFile]:
     global _bot_avatar_path
     if _bot_avatar_path and _is_usable_thumbnail_file(Path(_bot_avatar_path)):
         return FSInputFile(_bot_avatar_path)
-    if _bot_avatar_path:
-        Path(_bot_avatar_path).unlink(missing_ok=True)
-        _bot_avatar_path = None
 
-    try:
-        bot_id = await _get_bot_id(bot)
-        photos = await bot.get_user_profile_photos(bot_id, limit=1)
-        if not photos.total_count or not photos.photos:
-            return None
+    # Serialize download/normalize so concurrent cold-cache callers do not
+    # clobber each other's fixed temp files.
+    async with _bot_avatar_lock:
+        if _bot_avatar_path:
+            if _is_usable_thumbnail_file(Path(_bot_avatar_path)):
+                return FSInputFile(_bot_avatar_path)
+            Path(_bot_avatar_path).unlink(missing_ok=True)
+            _bot_avatar_path = None
 
-        avatar_path = _AUDIO_THUMB_PATH
-        avatar_path.parent.mkdir(parents=True, exist_ok=True)
-        file_id = _select_audio_thumbnail_file_id(photos.photos[0])
-        if not await _download_bot_avatar_file(bot, file_id, avatar_path):
+        try:
+            bot_id = await _get_bot_id(bot)
+            photos = await bot.get_user_profile_photos(bot_id, limit=1)
+            if not photos.total_count or not photos.photos:
+                return None
+
+            avatar_path = _AUDIO_THUMB_PATH
+            avatar_path.parent.mkdir(parents=True, exist_ok=True)
+            file_id = _select_audio_thumbnail_file_id(photos.photos[0])
+            if not await _download_bot_avatar_file(bot, file_id, avatar_path):
+                return None
+            _bot_avatar_path = str(avatar_path)
+            return FSInputFile(_bot_avatar_path)
+        except Exception as exc:
+            logging.debug("Failed to fetch bot avatar thumbnail: error=%s", exc)
             return None
-        _bot_avatar_path = str(avatar_path)
-        return FSInputFile(_bot_avatar_path)
-    except Exception as exc:
-        logging.debug("Failed to fetch bot avatar thumbnail: error=%s", exc)
-        return None
 
 
 async def _download_bot_avatar_file(bot: Bot, file_id: str, final_path: Path) -> bool:
@@ -110,7 +117,7 @@ async def _download_bot_avatar_file(bot: Bot, file_id: str, final_path: Path) ->
             final_path.unlink(missing_ok=True)
             return False
 
-        if _normalize_audio_thumbnail_file(temp_path, normalized_path):
+        if await asyncio.to_thread(_normalize_audio_thumbnail_file, temp_path, normalized_path):
             final_path.unlink(missing_ok=True)
             normalized_path.replace(final_path)
         else:

--- a/handlers/inline_utils.py
+++ b/handlers/inline_utils.py
@@ -1,13 +1,14 @@
 from typing import Any, Awaitable, Callable, Optional
 from urllib.parse import urlparse
 
-from aiogram import types
+from aiogram import F, Router, types
 from aiogram.client.default import Default
 from aiogram.methods.base import TelegramMethod
 from aiogram.exceptions import TelegramAPIError
 
 import keyboards as kb
 import messages as bm
+from handlers.logging_utils import with_callback_logging, with_chosen_inline_logging
 from services.logger import logger as logging, summarize_text_for_log
 
 _INLINE_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
@@ -315,3 +316,92 @@ def build_inline_album_result(
         ),
         reply_markup=reply_markup,
     )
+
+
+async def run_inline_send_callback(
+    call: types.CallbackQuery,
+    prefix: str,
+    sender_fn: Callable[..., Awaitable[None]],
+) -> None:
+    if not call.inline_message_id:
+        await call.answer("This button works only in inline mode.", show_alert=True)
+        return
+
+    token = call.data.removeprefix(prefix)
+    await call.answer()
+    try:
+        await sender_fn(
+            token=token,
+            inline_message_id=call.inline_message_id,
+            actor_name=call.from_user.full_name,
+            actor_user_id=call.from_user.id,
+            request_event_id=str(call.id),
+            duplicate_handler="callback",
+        )
+    except PermissionError:
+        await call.answer(bm.something_went_wrong(), show_alert=True)
+    except ValueError as exc:
+        if str(exc) == "already_processing":
+            await call.answer(bm.inline_video_already_processing(), show_alert=False)
+        elif str(exc) == "already_completed":
+            await call.answer(bm.inline_video_already_sent(), show_alert=False)
+        else:
+            await call.answer(bm.something_went_wrong(), show_alert=True)
+
+
+def register_inline_send_handlers(
+    router: Router,
+    *,
+    service: str,
+    result_prefix: str,
+    callback_prefix: str,
+    send_fn: Callable[..., Awaitable[None]],
+    missing_inline_message_warning: str,
+    chosen_flow: str = "chosen_inline",
+    callback_flow: str = "inline_callback",
+    chosen_handler_name: Optional[str] = None,
+    callback_handler_name: Optional[str] = None,
+) -> tuple[
+    Callable[[types.ChosenInlineResult], Awaitable[None]],
+    Callable[[types.CallbackQuery], Awaitable[None]],
+]:
+    async def _chosen_inline_result_handler(result: types.ChosenInlineResult) -> None:
+        if not result.inline_message_id:
+            logging.warning(missing_inline_message_warning)
+            return
+
+        token = result.result_id.removeprefix(result_prefix)
+        await send_fn(
+            token=token,
+            inline_message_id=result.inline_message_id,
+            actor_name=result.from_user.full_name,
+            actor_user_id=getattr(result.from_user, "id", None),
+            request_event_id=result.result_id,
+            duplicate_handler="chosen",
+        )
+
+    async def _send_inline_callback_handler(call: types.CallbackQuery) -> None:
+        await run_inline_send_callback(call, callback_prefix, send_fn)
+
+    if chosen_handler_name:
+        _chosen_inline_result_handler.__name__ = chosen_handler_name
+        _chosen_inline_result_handler.__qualname__ = chosen_handler_name
+    if callback_handler_name:
+        _send_inline_callback_handler.__name__ = callback_handler_name
+        _send_inline_callback_handler.__qualname__ = callback_handler_name
+
+    chosen_handler = with_chosen_inline_logging(service, chosen_flow)(
+        _chosen_inline_result_handler
+    )
+    chosen_handler = router.chosen_inline_result(
+        F.result_id.startswith(result_prefix)
+    )(chosen_handler)
+
+    callback_handler = with_callback_logging(service, callback_flow)(
+        _send_inline_callback_handler
+    )
+    callback_handler = router.callback_query(
+        F.data.startswith(callback_prefix)
+    )(callback_handler)
+
+    return chosen_handler, callback_handler

--- a/handlers/instagram.py
+++ b/handlers/instagram.py
@@ -4,7 +4,6 @@ import re
 from typing import Optional
 
 from aiogram import types, Router, F
-from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import FSInputFile
 
 import keyboards as kb
@@ -30,6 +29,7 @@ from handlers.utils import (
     handle_download_backpressure_error,
     handle_download_error,
     load_user_settings,
+    make_backpressure_handler,
     make_retry_status_notifier,
     make_status_text_progress_updater,
     maybe_delete_user_message,
@@ -43,8 +43,7 @@ from handlers.utils import (
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
     retry_async_operation,
-    with_callback_logging,
-    with_chosen_inline_logging,
+    register_inline_send_handlers,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -57,11 +56,11 @@ from services.logger import (
 from app_context import bot, db, send_analytics
 from services.media.delivery import (
     build_audio_cache_key,
+    make_video_or_document_senders,
     send_audio_with_thumbnail,
     send_cached_media_entries,
 )
 from services.media.orchestration import run_single_media_flow
-from services.media.video_metadata import build_video_send_kwargs
 from services.media.resolver import resolve_cached_media_items
 from services.platforms.instagram_media import (
     InstagramMedia,
@@ -251,33 +250,14 @@ async def process_instagram_video(
             audio_callback_data=audio_callback_data,
         )
 
-    async def _send_cached(file_id: str):
-        logging.info(
-            "Serving cached Instagram video: url=%s file_id=%s",
-            summarize_url_for_log(db_video_url),
-            file_id,
-        )
-        try:
-            if as_document:
-                return await message.reply_document(
-                    document=file_id,
-                    caption=bm.captions(
-                        user_settings["captions"], data.description, bot_url
-                    ),
-                    reply_markup=_reply_markup(),
-                    parse_mode="HTML",
-                    disable_content_type_detection=True,
-                )
-            return await message.reply_video(
-                video=file_id,
-                caption=bm.captions(
-                    user_settings["captions"], data.description, bot_url
-                ),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
-            )
-        except TelegramBadRequest:
-            return None
+    _send_cached, _send_downloaded, _extract_file_id = make_video_or_document_senders(
+        message,
+        caption=bm.captions(user_settings["captions"], data.description, bot_url),
+        reply_markup_fn=_reply_markup,
+        as_document=as_document,
+        cached_log_label="Instagram video",
+        cached_log_url=db_video_url,
+    )
 
     async def _download_media():
         return await asyncio.wait_for(
@@ -290,23 +270,6 @@ async def process_instagram_video(
                 on_retry=on_retry,
             ),
             timeout=420.0,
-        )
-
-    async def _send_downloaded(path: str):
-        if as_document:
-            return await message.reply_document(
-                document=FSInputFile(path),
-                caption=bm.captions(user_settings["captions"], data.description, bot_url),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
-                disable_content_type_detection=True,
-            )
-        return await message.reply_video(
-            video=FSInputFile(path),
-            caption=bm.captions(user_settings["captions"], data.description, bot_url),
-            reply_markup=_reply_markup(),
-            parse_mode="HTML",
-            **(await build_video_send_kwargs(path)),
         )
 
     async def _after_send():
@@ -324,12 +287,7 @@ async def process_instagram_video(
             return False
         return True
 
-    async def _handle_backpressure(exc: Exception) -> None:
-        await handle_download_backpressure_error(
-            exc,
-            message=message,
-            show_service_status=business_id is None,
-        )
+    _handle_backpressure = make_backpressure_handler(message, business_id)
 
     async def _handle_cache_store_error(exc: Exception) -> None:
         logging.error(
@@ -359,9 +317,7 @@ async def process_instagram_video(
         send_cached=_send_cached,
         download_media=_download_media,
         send_downloaded=_send_downloaded,
-        extract_file_id=lambda sent: (
-            sent.document.file_id if getattr(sent, "document", None) else (sent.video.file_id if getattr(sent, "video", None) else None)
-        ),
+        extract_file_id=_extract_file_id,
         cleanup_path=remove_file,
         delete_status_message=lambda: safe_delete_message(status_message),
         on_missing_media=lambda: handle_download_error(
@@ -660,49 +616,17 @@ async def _send_inline_instagram_video(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("instagram_inline:"))
-@with_chosen_inline_logging("instagram", "chosen_inline")
-async def chosen_inline_instagram_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning("Chosen inline Instagram result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("instagram_inline:")
-    await _send_inline_instagram_video(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_instagram_result, send_inline_instagram_video_callback = (
+    register_inline_send_handlers(
+        router,
+        service="instagram",
+        result_prefix="instagram_inline:",
+        callback_prefix="inline:instagram:",
+        send_fn=_send_inline_instagram_video,
+        missing_inline_message_warning=(
+            "Chosen inline Instagram result is missing inline_message_id"
+        ),
+        chosen_handler_name="chosen_inline_instagram_result",
+        callback_handler_name="send_inline_instagram_video_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:instagram:"))
-@with_callback_logging("instagram", "inline_callback")
-async def send_inline_instagram_video_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:instagram:")
-    await call.answer()
-    try:
-        await _send_inline_instagram_video(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
+)

--- a/handlers/instagram_inline.py
+++ b/handlers/instagram_inline.py
@@ -3,42 +3,35 @@ import re
 from typing import Optional
 
 from aiogram import types
-from aiogram.types import FSInputFile
 
 import keyboards as kb
 import messages as bm
 from handlers.deps import HandlerDependencies
 from handlers.utils import (
     build_inline_album_result,
-    build_inline_status_editor,
-    build_queue_busy_text,
-    build_rate_limit_text,
     build_start_deeplink_url,
     get_bot_url,
-    make_status_text_progress_updater,
-    remove_file,
     safe_answer_inline_query,
     safe_edit_inline_media,
     safe_edit_inline_text,
 )
 from services.logger import logger as logging, summarize_text_for_log, summarize_url_for_log
 from services.inline.album_links import create_inline_album_request
+from services.inline.send_flow import (
+    deliver_inline_photo,
+    deliver_inline_video,
+    ensure_album_preview_file_id,
+    run_inline_send_flow,
+)
 from services.inline.service_icons import get_inline_service_icon
 from services.inline.video_requests import (
-    claim_inline_video_request_for_send,
     complete_inline_video_request,
     create_inline_video_request,
     reset_inline_video_request,
 )
-from services.media.video_metadata import build_video_send_kwargs
 from services.platforms.instagram_media import (
     get_instagram_preview_url as _get_instagram_preview_url,
     strip_instagram_url,
-)
-from utils.download_manager import (
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    log_download_metrics,
 )
 from utils.media_cache import build_media_cache_key
 
@@ -146,25 +139,16 @@ async def handle_instagram_inline_query(
 
         if len(data.media_list) > 1:
             preview_file_id = None
-            if first_item and first_item.type == "photo" and channel_id:
-                cache_key = build_media_cache_key(original_url, item_index=0, item_kind="photo")
-                preview_file_id = await deps.db.get_file_id(cache_key)
-                if not preview_file_id:
-                    try:
-                        sent = await deps.bot.send_photo(
-                            chat_id=channel_id,
-                            photo=first_item.url,
-                            caption="Instagram Album Preview",
-                        )
-                        if sent.photo:
-                            preview_file_id = sent.photo[-1].file_id
-                            await deps.db.add_file(cache_key, preview_file_id, "photo")
-                    except Exception as exc:
-                        logging.warning(
-                            "Failed to cache Instagram album preview photo: url=%s error=%s",
-                            summarize_url_for_log(original_url),
-                            exc,
-                        )
+            if first_item and first_item.type == "photo":
+                preview_file_id = await ensure_album_preview_file_id(
+                    deps=deps,
+                    channel_id=channel_id,
+                    photo_url=first_item.url,
+                    cache_key=build_media_cache_key(original_url, item_index=0, item_kind="photo"),
+                    service_name="Instagram",
+                    source_url=original_url,
+                    log=logging,
+                )
             token = create_inline_album_request(query.from_user.id, "instagram", original_url)
             deep_link = build_start_deeplink_url(bot_url, f"album_{token}")
             results = [
@@ -206,69 +190,37 @@ async def send_inline_instagram_media(
     safe_edit_inline_media_fn=safe_edit_inline_media,
     safe_edit_inline_text_fn=safe_edit_inline_text,
 ) -> None:
-    request = claim_inline_video_request_for_send(
-        token,
-        duplicate_handler=duplicate_handler,
-        actor_user_id=actor_user_id,
-    )
-    if request is None:
-        return
-
-    download_path: Optional[str] = None
-
-    _edit_inline_status = build_inline_status_editor(
-        bot=deps.bot,
-        inline_message_id=inline_message_id,
-        callback_data_factory=lambda _media_kind: f"inline:instagram:{token}",
-        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
-    )
-
-    try:
+    async def _plan(request, edit_status, state) -> None:
         data = await inst_service.fetch_data(request.source_url)
         if not data or not data.media_list:
             reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True)
             return
 
         if len(data.media_list) != 1:
             complete_inline_video_request(token)
-            await _edit_inline_status(bm.inline_photos_not_supported("Instagram"))
+            await edit_status(bm.inline_photos_not_supported("Instagram"))
             return
+
+        async def _build_caption():
+            return bm.captions(
+                request.user_settings["captions"],
+                data.description,
+                await get_bot_url_fn(deps.bot),
+            )
 
         media = data.media_list[0]
         if media.type == "photo":
-            cache_key = build_media_cache_key(request.source_url, item_index=0, item_kind="photo")
-            db_id = await deps.db.get_file_id(cache_key)
-            if not db_id:
-                if not channel_id:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-                sent = await deps.bot.send_photo(
-                    chat_id=channel_id,
-                    photo=media.url,
-                    caption=f"Instagram Photo from {actor_name}",
-                )
-                if not sent.photo:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-                db_id = sent.photo[-1].file_id
-                await deps.db.add_file(cache_key, db_id, "photo")
-            else:
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-
-            bot_url = await get_bot_url_fn(deps.bot)
-            edited = await safe_edit_inline_media_fn(
-                deps.bot,
-                inline_message_id,
-                types.InputMediaPhoto(
-                    media=db_id,
-                    caption=bm.captions(request.user_settings["captions"], data.description, bot_url),
-                    parse_mode="HTML",
-                ),
+            await deliver_inline_photo(
+                deps=deps,
+                token=token,
+                inline_message_id=inline_message_id,
+                channel_id=channel_id,
+                service_name="Instagram",
+                cache_key=build_media_cache_key(request.source_url, item_index=0, item_kind="photo"),
+                photo_url=media.url,
+                channel_caption=f"Instagram Photo from {actor_name}",
+                build_caption=_build_caption,
                 reply_markup=kb.return_video_info_keyboard(
                     None,
                     None,
@@ -279,76 +231,43 @@ async def send_inline_instagram_media(
                     request.user_settings,
                     audio_callback_data=None,
                 ),
+                edit_status=edit_status,
+                safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+                log=logging,
             )
-            if edited:
-                complete_inline_video_request(token)
-                return
-
-            reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
             return
 
         if media.type != "video":
             complete_inline_video_request(token)
-            await _edit_inline_status(bm.inline_photos_not_supported("Instagram"))
+            await edit_status(bm.inline_photos_not_supported("Instagram"))
             return
 
         db_video_url = request.source_url
         audio_callback_data = f"audio:inst:{request.source_url}"
-        db_id = await deps.db.get_file_id(db_video_url)
-        if not db_id:
-            if not channel_id:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
 
+        async def _download(on_progress):
             timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
             download_name = f"{data.id}_{timestamp}_instagram_video.mp4"
-
-            await _edit_inline_status(bm.downloading_video_status())
-
-            on_progress = make_status_text_progress_updater("Instagram video", _edit_inline_status)
-
-            metrics = await inst_service.download_media(
+            return await inst_service.download_media(
                 media.url,
                 download_name,
                 user_id=request.owner_user_id,
                 request_id=f"instagram_inline:{request.owner_user_id}:{request_event_id}:{data.id}",
                 on_progress=on_progress,
             )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
 
-            log_download_metrics("instagram_inline", metrics)
-            download_path = metrics.path
-            if metrics.size >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.video_too_large())
-                return
-
-            await _edit_inline_status(bm.uploading_status())
-            sent = await deps.bot.send_video(
-                chat_id=channel_id,
-                video=FSInputFile(download_path),
-                caption=f"Instagram Video from {actor_name}",
-                **(await build_video_send_kwargs(download_path)),
-            )
-            db_id = sent.video.file_id
-            await deps.db.add_file(db_video_url, db_id, "video")
-        else:
-            await _edit_inline_status(bm.uploading_status())
-
-        bot_url = await get_bot_url_fn(deps.bot)
-        edited = await safe_edit_inline_media_fn(
-            deps.bot,
-            inline_message_id,
-            types.InputMediaVideo(
-                media=db_id,
-                caption=bm.captions(request.user_settings["captions"], data.description, bot_url),
-                parse_mode="HTML",
-            ),
+        await deliver_inline_video(
+            deps=deps,
+            token=token,
+            inline_message_id=inline_message_id,
+            channel_id=channel_id,
+            max_file_size=max_file_size,
+            service_name="Instagram",
+            cache_key=db_video_url,
+            channel_caption=f"Instagram Video from {actor_name}",
+            download_fn=_download,
+            progress_label="Instagram video",
+            build_caption=_build_caption,
             reply_markup=kb.return_video_info_keyboard(
                 None,
                 None,
@@ -359,22 +278,22 @@ async def send_inline_instagram_media(
                 request.user_settings,
                 audio_callback_data=audio_callback_data,
             ),
+            edit_status=edit_status,
+            state=state,
+            safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+            metrics_log_key="instagram_inline",
+            log=logging,
         )
-        if edited:
-            complete_inline_video_request(token)
-            return
 
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    except DownloadRateLimitError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_rate_limit_text(exc.retry_after), with_retry_button=True)
-    except DownloadQueueBusyError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_queue_busy_text(exc.position), with_retry_button=True)
-    except Exception:
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    finally:
-        if download_path:
-            await remove_file(download_path)
+    await run_inline_send_flow(
+        token=token,
+        inline_message_id=inline_message_id,
+        actor_user_id=actor_user_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service_name="Instagram",
+        callback_data=f"inline:instagram:{token}",
+        plan_fn=_plan,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        log=logging,
+    )

--- a/handlers/logging_utils.py
+++ b/handlers/logging_utils.py
@@ -12,6 +12,8 @@ from services.logger import logger as logging
 T = TypeVar("T")
 P = ParamSpec("P")
 
+FlowDecorator = Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]
+
 
 def build_request_id(prefix: str, *parts: Any) -> str:
     normalized_parts: list[str] = []
@@ -41,24 +43,22 @@ def log_duration(event_name: str, started_at: float, **fields: Any) -> None:
     )
 
 
-def with_message_logging(service: str, flow: str) -> Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]:
+def _make_flow_decorator(
+    service: str,
+    flow: str,
+    extract: Callable[[tuple, dict], tuple[tuple, dict]],
+) -> FlowDecorator:
     def decorator(func: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
         @wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            message: types.Message = args[0]  # type: ignore[assignment]
-            request_id = build_request_id(
-                f"{service}-{flow}",
-                getattr(getattr(message, "from_user", None), "id", None),
-                getattr(message, "chat", None).id if getattr(message, "chat", None) else None,
-                getattr(message, "message_id", None),
-            )
+            request_id_parts, context_fields = extract(args, kwargs)
+            request_id = build_request_id(f"{service}-{flow}", *request_id_parts)
             started_at = time.perf_counter()
             with logging.context(
                 service=service,
                 flow=flow,
                 request_id=request_id,
-                user_id=getattr(getattr(message, "from_user", None), "id", None),
-                chat_type=getattr(getattr(message, "chat", None), "type", None),
+                **context_fields,
             ):
                 logging.event("flow_started", entrypoint=func.__name__)
                 try:
@@ -76,137 +76,68 @@ def with_message_logging(service: str, flow: str) -> Callable[[Callable[P, Await
     return decorator
 
 
-def with_inline_query_logging(service: str, flow: str) -> Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]:
-    def decorator(func: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            query: types.InlineQuery = args[0]  # type: ignore[assignment]
-            request_id = build_request_id(
-                f"{service}-{flow}",
-                getattr(getattr(query, "from_user", None), "id", None),
-                getattr(query, "id", None),
-            )
-            started_at = time.perf_counter()
-            with logging.context(
-                service=service,
-                flow=flow,
-                request_id=request_id,
-                user_id=getattr(getattr(query, "from_user", None), "id", None),
-                chat_type=getattr(query, "chat_type", None),
-            ):
-                logging.event("flow_started", entrypoint=func.__name__)
-                try:
-                    result = await func(*args, **kwargs)
-                    logging.event("flow_completed", entrypoint=func.__name__)
-                    return result
-                except Exception as exc:
-                    logging.event("flow_failed", level=40, entrypoint=func.__name__, error=str(exc))
-                    raise
-                finally:
-                    log_duration("flow_total", started_at, entrypoint=func.__name__)
+def with_message_logging(service: str, flow: str) -> FlowDecorator:
+    def extract(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+        message: types.Message = args[0]  # type: ignore[assignment]
+        user_id = getattr(getattr(message, "from_user", None), "id", None)
+        chat = getattr(message, "chat", None)
+        return (
+            (user_id, chat.id if chat else None, getattr(message, "message_id", None)),
+            {"user_id": user_id, "chat_type": getattr(chat, "type", None)},
+        )
 
-        return wrapper
-
-    return decorator
+    return _make_flow_decorator(service, flow, extract)
 
 
-def with_callback_logging(service: str, flow: str) -> Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]:
-    def decorator(func: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            call: types.CallbackQuery = args[0]  # type: ignore[assignment]
-            request_id = build_request_id(
-                f"{service}-{flow}",
-                getattr(getattr(call, "from_user", None), "id", None),
-                getattr(call, "id", None),
-            )
-            started_at = time.perf_counter()
-            with logging.context(
-                service=service,
-                flow=flow,
-                request_id=request_id,
-                user_id=getattr(getattr(call, "from_user", None), "id", None),
-                chat_type=getattr(getattr(call, "message", None), "chat", None).type
-                if getattr(getattr(call, "message", None), "chat", None)
-                else None,
-                inline_message_id=getattr(call, "inline_message_id", None),
-            ):
-                logging.event("flow_started", entrypoint=func.__name__)
-                try:
-                    result = await func(*args, **kwargs)
-                    logging.event("flow_completed", entrypoint=func.__name__)
-                    return result
-                except Exception as exc:
-                    logging.event("flow_failed", level=40, entrypoint=func.__name__, error=str(exc))
-                    raise
-                finally:
-                    log_duration("flow_total", started_at, entrypoint=func.__name__)
+def with_inline_query_logging(service: str, flow: str) -> FlowDecorator:
+    def extract(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+        query: types.InlineQuery = args[0]  # type: ignore[assignment]
+        user_id = getattr(getattr(query, "from_user", None), "id", None)
+        return (
+            (user_id, getattr(query, "id", None)),
+            {"user_id": user_id, "chat_type": getattr(query, "chat_type", None)},
+        )
 
-        return wrapper
-
-    return decorator
+    return _make_flow_decorator(service, flow, extract)
 
 
-def with_chosen_inline_logging(service: str, flow: str) -> Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]:
-    def decorator(func: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            result: types.ChosenInlineResult = args[0]  # type: ignore[assignment]
-            request_id = build_request_id(
-                f"{service}-{flow}",
-                getattr(getattr(result, "from_user", None), "id", None),
-                getattr(result, "result_id", None),
-            )
-            started_at = time.perf_counter()
-            with logging.context(
-                service=service,
-                flow=flow,
-                request_id=request_id,
-                user_id=getattr(getattr(result, "from_user", None), "id", None),
-                inline_message_id=getattr(result, "inline_message_id", None),
-            ):
-                logging.event("flow_started", entrypoint=func.__name__)
-                try:
-                    outcome = await func(*args, **kwargs)
-                    logging.event("flow_completed", entrypoint=func.__name__)
-                    return outcome
-                except Exception as exc:
-                    logging.event("flow_failed", level=40, entrypoint=func.__name__, error=str(exc))
-                    raise
-                finally:
-                    log_duration("flow_total", started_at, entrypoint=func.__name__)
+def with_callback_logging(service: str, flow: str) -> FlowDecorator:
+    def extract(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+        call: types.CallbackQuery = args[0]  # type: ignore[assignment]
+        user_id = getattr(getattr(call, "from_user", None), "id", None)
+        chat = getattr(getattr(call, "message", None), "chat", None)
+        return (
+            (user_id, getattr(call, "id", None)),
+            {
+                "user_id": user_id,
+                "chat_type": chat.type if chat else None,
+                "inline_message_id": getattr(call, "inline_message_id", None),
+            },
+        )
 
-        return wrapper
-
-    return decorator
+    return _make_flow_decorator(service, flow, extract)
 
 
-def with_inline_send_logging(service: str, flow: str) -> Callable[[Callable[P, Awaitable[Any]]], Callable[P, Awaitable[Any]]]:
-    def decorator(func: Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]:
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            token = kwargs.get("token")
-            inline_message_id = kwargs.get("inline_message_id")
-            request_event_id = kwargs.get("request_event_id")
-            request_id = build_request_id(f"{service}-{flow}", token, request_event_id)
-            started_at = time.perf_counter()
-            with logging.context(
-                service=service,
-                flow=flow,
-                request_id=request_id,
-                inline_message_id=inline_message_id,
-            ):
-                logging.event("flow_started", entrypoint=func.__name__)
-                try:
-                    outcome = await func(*args, **kwargs)
-                    logging.event("flow_completed", entrypoint=func.__name__)
-                    return outcome
-                except Exception as exc:
-                    logging.event("flow_failed", level=40, entrypoint=func.__name__, error=str(exc))
-                    raise
-                finally:
-                    log_duration("flow_total", started_at, entrypoint=func.__name__)
+def with_chosen_inline_logging(service: str, flow: str) -> FlowDecorator:
+    def extract(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+        result: types.ChosenInlineResult = args[0]  # type: ignore[assignment]
+        user_id = getattr(getattr(result, "from_user", None), "id", None)
+        return (
+            (user_id, getattr(result, "result_id", None)),
+            {
+                "user_id": user_id,
+                "inline_message_id": getattr(result, "inline_message_id", None),
+            },
+        )
 
-        return wrapper
+    return _make_flow_decorator(service, flow, extract)
 
-    return decorator
+
+def with_inline_send_logging(service: str, flow: str) -> FlowDecorator:
+    def extract(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+        return (
+            (kwargs.get("token"), kwargs.get("request_event_id")),
+            {"inline_message_id": kwargs.get("inline_message_id")},
+        )
+
+    return _make_flow_decorator(service, flow, extract)

--- a/handlers/media_download.py
+++ b/handlers/media_download.py
@@ -4,20 +4,26 @@ from aiogram import types
 
 import keyboards as kb
 import messages as bm
+from app_context import bot, send_analytics
 from config import (
     BATCH_LINKS_MAX_CONCURRENCY,
+    BATCH_LINKS_MAX_ITEMS,
     BATCH_LINKS_MIN_CONCURRENCY,
     BATCH_LINKS_PARALLEL_ACTIVE_JOBS_THRESHOLD,
     BATCH_LINKS_PARALLEL_QUEUE_DEPTH_THRESHOLD,
 )
+from handlers.commands import update_info
 from handlers.utils import get_bot_username, get_message_text, safe_delete_message
+from services.download.queue import get_download_queue
 from services.logger import logger as logging, summarize_url_for_log
 from services.stats.constants import SERVICE_DISPLAY_NAMES
 from services.inline.album_links import get_inline_album_request
 from services.links.detection import extract_supported_link, extract_supported_links
-import handlers.user as user_mod
 
 logging = logging.bind(service="media_download")
+
+_MAX_BATCH_LINKS = max(1, int(BATCH_LINKS_MAX_ITEMS))
+_ALBUM_SERVICES = {"instagram", "threads", "tiktok", "pinterest", "twitter"}
 
 
 async def _process_inline_album_deeplink(message: types.Message, payload: str) -> bool:
@@ -33,25 +39,8 @@ async def _process_inline_album_deeplink(message: types.Message, payload: str) -
         return True
 
     try:
-        if request.service == "instagram":
-            from handlers import instagram
-            await instagram.process_instagram(message, direct_url=request.url)
-            return True
-        if request.service == "threads":
-            from handlers import threads
-            await threads.process_threads(message, direct_url=request.url)
-            return True
-        if request.service == "tiktok":
-            from handlers import tiktok
-            await tiktok.process_tiktok(message, direct_url=request.url)
-            return True
-        if request.service == "pinterest":
-            from handlers import pinterest
-            await pinterest.process_pinterest(message, direct_url=request.url)
-            return True
-        if request.service == "twitter":
-            from handlers import twitter
-            await twitter.handle_tweet_links(message, direct_url=request.url)
+        if request.service in _ALBUM_SERVICES:
+            await _process_supported_link(message, request.service, request.url)
             return True
     except Exception:
         logging.exception(
@@ -73,7 +62,7 @@ async def _process_pending_message(message: types.Message) -> None:
     if not detected:
         return
     service, url = detected
-    await user_mod._process_supported_link(message, service, url)
+    await _process_supported_link(message, service, url)
 
 
 async def _process_supported_link(message: types.Message, service: str, url: str) -> None:
@@ -127,7 +116,7 @@ def _has_multiple_supported_links(message: types.Message) -> bool:
 def _resolve_batch_concurrency() -> int:
     min_concurrency = max(1, int(BATCH_LINKS_MIN_CONCURRENCY))
     max_concurrency = max(min_concurrency, int(BATCH_LINKS_MAX_CONCURRENCY))
-    load = user_mod.get_download_queue().load_snapshot()
+    load = get_download_queue().load_snapshot()
     if (
         load.queued_jobs > int(BATCH_LINKS_PARALLEL_QUEUE_DEPTH_THRESHOLD)
         or load.active_jobs >= int(BATCH_LINKS_PARALLEL_ACTIVE_JOBS_THRESHOLD)
@@ -141,15 +130,15 @@ async def process_batch_links(message: types.Message):
     if len(links) <= 1:
         return
 
-    selected_links = links[:user_mod._MAX_BATCH_LINKS]
-    await user_mod.send_analytics(
+    selected_links = links[:_MAX_BATCH_LINKS]
+    await send_analytics(
         user_id=message.from_user.id,
         chat_type=message.chat.type,
         action_name="batch_links",
     )
-    await user_mod.update_info(message)
+    await update_info(message)
 
-    concurrency = min(len(selected_links), user_mod._resolve_batch_concurrency())
+    concurrency = min(len(selected_links), _resolve_batch_concurrency())
     status_message = await message.answer(
         bm.batch_links_started(len(selected_links), len(links)),
         parse_mode="HTML",
@@ -157,7 +146,7 @@ async def process_batch_links(message: types.Message):
     try:
         if concurrency > 1:
             await safe_delete_message(status_message)
-            await user_mod._process_batch_links_parallel(message, selected_links, concurrency)
+            await _process_batch_links_parallel(message, selected_links, concurrency)
             status_message = await message.answer(bm.batch_links_finished(len(selected_links)))
             return
 
@@ -168,7 +157,7 @@ async def process_batch_links(message: types.Message):
                 bm.batch_link_progress(index, len(selected_links), service_name),
             )
             try:
-                await user_mod._process_supported_link(message, service, url)
+                await _process_supported_link(message, service, url)
             except Exception as exc:
                 logging.exception(
                     "Batch link failed: user_id=%s service=%s url=%s error=%s",
@@ -201,7 +190,7 @@ async def _process_batch_links_parallel(
                 bm.batch_link_progress(index, total, service_name),
             )
             try:
-                await user_mod._process_supported_link(message, service, url)
+                await _process_supported_link(message, service, url)
             except Exception as exc:
                 logging.exception(
                     "Parallel batch link failed: user_id=%s service=%s url=%s error=%s",
@@ -220,7 +209,7 @@ async def _process_batch_links_parallel(
 
 
 async def show_supported_sites(call: types.CallbackQuery):
-    bot_username = await get_bot_username(user_mod.bot)
+    bot_username = await get_bot_username(bot)
     await call.message.edit_text(
         bm.help_message(bot_username),
         reply_markup=kb.start_keyboard(bot_username, ref_user_id=call.from_user.id),

--- a/handlers/pinterest.py
+++ b/handlers/pinterest.py
@@ -15,8 +15,11 @@ from handlers.pinterest_inline import handle_pinterest_inline_query, send_inline
 from handlers.request_dedupe import claim_message_request
 from services.media.delivery import send_cached_media_entries
 from services.media.video_metadata import build_video_send_kwargs
-from services.media.orchestration import handle_download_backpressure, run_single_media_flow
-from services.media.resolver import resolve_cached_media_items
+from services.media.orchestration import (
+    make_message_backpressure_handler,
+    run_media_group_flow,
+    run_single_media_flow,
+)
 from services.platforms.pinterest_media import (
     PinterestMedia,
     PinterestMediaService,
@@ -38,6 +41,7 @@ from handlers.utils import (
     maybe_delete_user_message,
     react_to_message,
     remove_file,
+    register_inline_send_handlers,
     retry_async_operation,
     safe_delete_message,
     safe_edit_text,
@@ -46,8 +50,6 @@ from handlers.utils import (
     safe_answer_inline_query,
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
-    with_callback_logging,
-    with_chosen_inline_logging,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -127,12 +129,10 @@ async def process_pinterest(message: types.Message, direct_url: Optional[str] = 
             return
 
         first = post.media_list[0]
-        if len(post.media_list) == 1 and first.type == "video":
-            if await process_pinterest_single_video(message, post, source_url, bot_url, user_settings, business_id):
-                request_lease.mark_success()
-            return
-        if len(post.media_list) == 1 and first.type == "photo":
-            if await process_pinterest_single_photo(message, post, source_url, bot_url, user_settings, business_id):
+        if len(post.media_list) == 1 and first.type in ("video", "photo"):
+            if await process_pinterest_single_media(
+                message, post, source_url, bot_url, user_settings, business_id, first.type
+            ):
                 request_lease.mark_success()
             return
         if await process_pinterest_media_group(message, post, source_url, bot_url, user_settings, business_id):
@@ -155,29 +155,35 @@ async def process_pinterest_url(message: types.Message, url: Optional[str] = Non
     await process_pinterest(message, direct_url=url)
 
 
-async def process_pinterest_single_video(
+async def process_pinterest_single_media(
     message: types.Message,
     post: PinterestPost,
     source_url: str,
     bot_url: str,
     user_settings: dict,
     business_id: Optional[int],
+    media_kind: str,
 ):
     media = post.media_list[0]
     status_message: Optional[types.Message] = None
     if business_id is None:
         status_message = await message.answer(bm.downloading_video_status())
+
+    extension = "mp4"
+    if media_kind == "photo":
+        extension = "jpg"
+        low_url = media.url.lower().split("?", 1)[0]
+        if low_url.endswith(".png"):
+            extension = "png"
     timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    download_name = f"{post.id}_{timestamp}_pinterest_video.mp4"
+    filename = f"{post.id}_{timestamp}_pinterest_{media_kind}.{extension}"
+    cache_key = source_url if media_kind == "video" else f"{source_url}#photo"
 
     async def _edit_status(text: str) -> None:
         await safe_edit_text(status_message, text)
 
-    on_progress = make_status_text_progress_updater("Pinterest video", _edit_status)
-    on_retry = make_retry_status_notifier(
-        _edit_status,
-        enabled=business_id is None,
-    )
+    on_progress = make_status_text_progress_updater(f"Pinterest {media_kind}", _edit_status)
+    on_retry = make_retry_status_notifier(_edit_status, enabled=business_id is None)
 
     def _reply_markup():
         return kb.return_video_info_keyboard(
@@ -186,111 +192,18 @@ async def process_pinterest_single_video(
         )
 
     async def _download_media():
-        return await asyncio.wait_for(
-            pinterest_service.download_media(
-                media.url,
-                download_name,
-                user_id=message.from_user.id,
-                chat_id=message.chat.id,
-                on_progress=on_progress,
-                on_retry=on_retry,
-            ),
-            timeout=420.0,
-        )
-
-    async def _send_cached(file_id: str):
-        try:
-            return await message.reply_video(
-                video=file_id,
-                caption=bm.captions(user_settings["captions"], post.description, bot_url),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
+        if media_kind == "video":
+            return await asyncio.wait_for(
+                pinterest_service.download_media(
+                    media.url,
+                    filename,
+                    user_id=message.from_user.id,
+                    chat_id=message.chat.id,
+                    on_progress=on_progress,
+                    on_retry=on_retry,
+                ),
+                timeout=420.0,
             )
-        except TelegramBadRequest:
-            return None
-
-    async def _send_downloaded(path: str):
-        return await message.reply_video(
-            video=FSInputFile(path),
-            caption=bm.captions(user_settings["captions"], post.description, bot_url),
-            reply_markup=_reply_markup(),
-            parse_mode="HTML",
-            **(await build_video_send_kwargs(path)),
-        )
-
-    async def _after_send():
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-
-    async def _inspect_metrics(metrics: DownloadMetrics) -> bool:
-        log_download_metrics("pinterest_video", metrics)
-        if metrics.size >= MAX_FILE_SIZE:
-            await handle_download_error(message, business_id=business_id, text=bm.video_too_large())
-            return False
-        return True
-
-    async def _handle_backpressure(exc: Exception) -> None:
-        await handle_download_backpressure(
-            exc,
-            business_id=business_id,
-            on_rate_limit_reply=lambda retry_after: message.reply(build_rate_limit_text(retry_after)),
-            on_queue_busy_reply=lambda position: message.reply(build_queue_busy_text(position)),
-            on_business_error=lambda: handle_download_error(message, business_id=business_id),
-        )
-
-    sent_message = await run_single_media_flow(
-        cache_key=source_url,
-        cache_file_type="video",
-        db_service=db,
-        upload_status_text=bm.uploading_status(),
-        upload_action="upload_video",
-        update_status=_edit_status,
-        send_chat_action=lambda action: send_chat_action_if_needed(bot, message.chat.id, action, business_id),
-        send_cached=_send_cached,
-        download_media=_download_media,
-        send_downloaded=_send_downloaded,
-        extract_file_id=lambda sent: sent.video.file_id if getattr(sent, "video", None) else None,
-        cleanup_path=remove_file,
-        delete_status_message=lambda: safe_delete_message(status_message),
-        on_missing_media=lambda: handle_download_error(message, business_id=business_id),
-        on_after_send=_after_send,
-        inspect_metrics=_inspect_metrics,
-        on_rate_limit=_handle_backpressure,
-        on_queue_busy=_handle_backpressure,
-    )
-    return sent_message is not None
-
-
-async def process_pinterest_single_photo(
-    message: types.Message,
-    post: PinterestPost,
-    source_url: str,
-    bot_url: str,
-    user_settings: dict,
-    business_id: Optional[int],
-):
-    media = post.media_list[0]
-    cache_key = f"{source_url}#photo"
-    status_message: Optional[types.Message] = None
-    if business_id is None:
-        status_message = await message.answer(bm.downloading_video_status())
-
-    ext = "jpg"
-    low_url = media.url.lower().split("?", 1)[0]
-    if low_url.endswith(".png"):
-        ext = "png"
-    timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    filename = f"{post.id}_{timestamp}_pinterest_photo.{ext}"
-
-    async def _edit_status(text: str) -> None:
-        await safe_edit_text(status_message, text)
-
-    def _reply_markup():
-        return kb.return_video_info_keyboard(
-            None, None, None, None, None, source_url, user_settings,
-            audio_callback_data=None,
-        )
-
-    async def _download_media():
         return await pinterest_service.download_media(
             media.url,
             filename,
@@ -301,6 +214,13 @@ async def process_pinterest_single_photo(
 
     async def _send_cached(file_id: str):
         try:
+            if media_kind == "video":
+                return await message.reply_video(
+                    video=file_id,
+                    caption=bm.captions(user_settings["captions"], post.description, bot_url),
+                    reply_markup=_reply_markup(),
+                    parse_mode="HTML",
+                )
             return await message.reply_photo(
                 photo=file_id,
                 caption=bm.captions(user_settings["captions"], post.description, bot_url),
@@ -311,6 +231,14 @@ async def process_pinterest_single_photo(
             return None
 
     async def _send_downloaded(path: str):
+        if media_kind == "video":
+            return await message.reply_video(
+                video=FSInputFile(path),
+                caption=bm.captions(user_settings["captions"], post.description, bot_url),
+                reply_markup=_reply_markup(),
+                parse_mode="HTML",
+                **(await build_video_send_kwargs(path)),
+            )
         return await message.reply_photo(
             photo=FSInputFile(path),
             caption=bm.captions(user_settings["captions"], post.description, bot_url),
@@ -318,32 +246,76 @@ async def process_pinterest_single_photo(
             parse_mode="HTML",
         )
 
-    async def _after_send():
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-
     async def _inspect_metrics(metrics: DownloadMetrics) -> bool:
-        log_download_metrics("pinterest_photo", metrics)
+        log_download_metrics(f"pinterest_{media_kind}", metrics)
+        if media_kind == "video" and metrics.size >= MAX_FILE_SIZE:
+            await handle_download_error(message, business_id=business_id, text=bm.video_too_large())
+            return False
         return True
+
+    _handle_backpressure = (
+        make_message_backpressure_handler(
+            message,
+            business_id,
+            build_rate_limit_text=build_rate_limit_text,
+            build_queue_busy_text=build_queue_busy_text,
+            handle_download_error=handle_download_error,
+        )
+        if media_kind == "video"
+        else None
+    )
 
     sent_message = await run_single_media_flow(
         cache_key=cache_key,
-        cache_file_type="photo",
+        cache_file_type=media_kind,
         db_service=db,
         upload_status_text=bm.uploading_status(),
-        upload_action="upload_photo",
+        upload_action="upload_video" if media_kind == "video" else "upload_photo",
         update_status=_edit_status,
         send_chat_action=lambda action: send_chat_action_if_needed(bot, message.chat.id, action, business_id),
         send_cached=_send_cached,
         download_media=_download_media,
         send_downloaded=_send_downloaded,
-        extract_file_id=lambda sent: sent.photo[-1].file_id if getattr(sent, "photo", None) else None,
+        extract_file_id=lambda sent: (
+            sent.video.file_id if media_kind == "video" and getattr(sent, "video", None)
+            else sent.photo[-1].file_id if media_kind == "photo" and getattr(sent, "photo", None)
+            else None
+        ),
         cleanup_path=remove_file,
         delete_status_message=lambda: safe_delete_message(status_message),
         on_missing_media=lambda: handle_download_error(message, business_id=business_id),
-        on_after_send=_after_send,
+        on_after_send=lambda: maybe_delete_user_message(message, user_settings["delete_message"]),
         inspect_metrics=_inspect_metrics,
+        on_rate_limit=_handle_backpressure,
+        on_queue_busy=_handle_backpressure,
     )
     return sent_message is not None
+
+
+async def process_pinterest_single_video(
+    message: types.Message,
+    post: PinterestPost,
+    source_url: str,
+    bot_url: str,
+    user_settings: dict,
+    business_id: Optional[int],
+):
+    return await process_pinterest_single_media(
+        message, post, source_url, bot_url, user_settings, business_id, "video"
+    )
+
+
+async def process_pinterest_single_photo(
+    message: types.Message,
+    post: PinterestPost,
+    source_url: str,
+    bot_url: str,
+    user_settings: dict,
+    business_id: Optional[int],
+):
+    return await process_pinterest_single_media(
+        message, post, source_url, bot_url, user_settings, business_id, "photo"
+    )
 
 
 async def process_pinterest_media_group(
@@ -371,8 +343,24 @@ async def process_pinterest_media_group(
             request_id=request_id,
         )
 
-    media_items, downloaded_paths = await resolve_cached_media_items(
-        post.media_list,
+    async def _send_entries(media_items: list[dict]) -> None:
+        caption = bm.captions(user_settings["captions"], post.description, bot_url)
+        keyboard = kb.return_video_info_keyboard(
+            None, None, None, None, None, source_url, user_settings,
+            audio_callback_data=None,
+        )
+        await send_cached_media_entries(
+            message,
+            media_items,
+            db_service=db,
+            caption=caption,
+            reply_markup=keyboard,
+            parse_mode="HTML",
+            kind_key="type",
+        )
+
+    return await run_media_group_flow(
+        media_list=post.media_list,
         db_service=db,
         kind_getter=lambda item: item.type,
         build_cache_key=lambda index, _item, media_kind: build_media_cache_key(
@@ -383,34 +371,14 @@ async def process_pinterest_media_group(
         download_item=_download_item,
         metrics_label="pinterest_group",
         error_label="Pinterest",
+        update_status=lambda text: safe_edit_text(status_message, text),
+        upload_status_text=bm.uploading_status(),
+        send_entries=_send_entries,
+        on_empty=lambda: handle_download_error(message, business_id=business_id),
+        delete_status_message=lambda: safe_delete_message(status_message),
+        cleanup_path=remove_file,
+        on_after_send=lambda: maybe_delete_user_message(message, user_settings["delete_message"]),
     )
-
-    if not media_items:
-        await handle_download_error(message, business_id=business_id)
-        return False
-
-    try:
-        caption = bm.captions(user_settings["captions"], post.description, bot_url)
-        keyboard = kb.return_video_info_keyboard(
-            None, None, None, None, None, source_url, user_settings,
-            audio_callback_data=None,
-        )
-        await safe_edit_text(status_message, bm.uploading_status())
-        await send_cached_media_entries(
-            message,
-            media_items,
-            db_service=db,
-            caption=caption,
-            reply_markup=keyboard,
-            parse_mode="HTML",
-            kind_key="type",
-        )
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-        return True
-    finally:
-        await safe_delete_message(status_message)
-        for path in downloaded_paths:
-            await remove_file(path)
 
 
 @router.inline_query(F.query.regexp(PINTEREST_URL_REGEX, mode="search"))
@@ -457,49 +425,17 @@ async def _send_inline_pinterest_video(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("pinterest_inline:"))
-@with_chosen_inline_logging("pinterest", "chosen_inline")
-async def chosen_inline_pinterest_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning("Chosen inline Pinterest result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("pinterest_inline:")
-    await _send_inline_pinterest_video(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_pinterest_result, send_inline_pinterest_video_callback = (
+    register_inline_send_handlers(
+        router,
+        service="pinterest",
+        result_prefix="pinterest_inline:",
+        callback_prefix="inline:pinterest:",
+        send_fn=_send_inline_pinterest_video,
+        missing_inline_message_warning=(
+            "Chosen inline Pinterest result is missing inline_message_id"
+        ),
+        chosen_handler_name="chosen_inline_pinterest_result",
+        callback_handler_name="send_inline_pinterest_video_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:pinterest:"))
-@with_callback_logging("pinterest", "inline_callback")
-async def send_inline_pinterest_video_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:pinterest:")
-    await call.answer()
-    try:
-        await _send_inline_pinterest_video(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
+)

--- a/handlers/pinterest_inline.py
+++ b/handlers/pinterest_inline.py
@@ -1,45 +1,19 @@
-import datetime
-import re
 from typing import Optional
 
 from aiogram import types
-from aiogram.types import FSInputFile
 
-import keyboards as kb
-import messages as bm
 from handlers.deps import HandlerDependencies
 from handlers.utils import (
-    build_inline_album_result,
-    build_inline_status_editor,
-    build_queue_busy_text,
-    build_rate_limit_text,
-    build_start_deeplink_url,
     get_bot_url,
-    make_status_text_progress_updater,
-    remove_file,
     safe_answer_inline_query,
     safe_edit_inline_media,
     safe_edit_inline_text,
 )
-from services.logger import logger as logging, summarize_text_for_log, summarize_url_for_log
-from services.inline.album_links import create_inline_album_request
-from services.inline.service_icons import get_inline_service_icon
-from services.inline.video_requests import (
-    claim_inline_video_request_for_send,
-    complete_inline_video_request,
-    create_inline_video_request,
-    reset_inline_video_request,
-)
-from services.media.video_metadata import build_video_send_kwargs
+from services.logger import logger
+from services.inline.send_flow import handle_post_inline_query, send_inline_post_media
 from services.platforms.pinterest_media import get_pinterest_preview_url as _get_pinterest_preview_url
-from utils.download_manager import (
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    log_download_metrics,
-)
-from utils.media_cache import build_media_cache_key
 
-logging = logging.bind(service="pinterest_inline")
+logging = logger.bind(service="pinterest_inline")
 
 
 async def handle_pinterest_inline_query(
@@ -58,184 +32,22 @@ async def handle_pinterest_inline_query(
     get_bot_url_fn=get_bot_url,
     safe_answer_inline_query_fn=safe_answer_inline_query,
 ) -> None:
-    try:
-        await deps.send_analytics(
-            user_id=query.from_user.id,
-            chat_type=query.chat_type,
-            action_name=analytics_action,
-        )
-        match = re.search(pinterest_url_regex, query.query or "")
-        if not match:
-            await query.answer([], cache_time=1, is_personal=True)
-            return
-        source_url = strip_pinterest_url(match.group(0))
-        user_settings = await deps.db.user_settings(query.from_user.id)
-        bot_url = await get_bot_url_fn(deps.bot)
-
-        post = await pinterest_service.fetch_post(source_url)
-        if not post:
-            await query.answer([], cache_time=1, is_personal=True)
-            return
-        if not post.media_list:
-            if not allow_text_only:
-                await query.answer([], cache_time=1, is_personal=True)
-                return
-            results = [
-                types.InlineQueryResultArticle(
-                    id=f"{service_key}_text_{post.id}",
-                    title=f"{service_name} Post",
-                    description=post.description or f"Text post from {service_name}.",
-                    thumbnail_url=get_inline_service_icon(service_key),
-                    input_message_content=types.InputTextMessageContent(
-                        message_text=bm.captions("on", post.description, bot_url, limit=4096),
-                        parse_mode="HTML",
-                    ),
-                    reply_markup=kb.return_video_info_keyboard(
-                        None, None, None, None, None, source_url, user_settings,
-                        audio_callback_data=None,
-                    ),
-                )
-            ]
-            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-            return
-        if not channel_id:
-            logging.error("CHANNEL_ID is not configured; %s inline media is disabled", service_name)
-            await query.answer([], cache_time=1, is_personal=True)
-            return
-        first = post.media_list[0]
-        photo_items = [item for item in post.media_list if item.type == "photo"]
-        first_photo = photo_items[0] if photo_items else None
-        first_preview = get_preview_url(first) or next(
-            (get_preview_url(item) for item in post.media_list if get_preview_url(item)),
-            None,
-        )
-
-        if len(post.media_list) == 1 and first_photo:
-            cache_key = f"{source_url}#photo"
-            db_id = await deps.db.get_file_id(cache_key)
-            if not db_id and not channel_id:
-                logging.error("CHANNEL_ID is not configured; %s inline photo send is disabled", service_name)
-                await query.answer([], cache_time=1, is_personal=True)
-                return
-
-            token = create_inline_video_request(service_key, source_url, query.from_user.id, user_settings)
-            results = [
-                types.InlineQueryResultArticle(
-                    id=f"{service_key}_inline:{token}",
-                    title=f"{service_name} Photo",
-                    description=post.description or "Press the button to send this photo inline.",
-                    thumbnail_url=first_preview,
-                    input_message_content=types.InputTextMessageContent(
-                        message_text=f"{service_name} photo is being prepared...\nIf it does not start automatically, tap the button below.",
-                    ),
-                    reply_markup=kb.inline_send_media_keyboard(
-                        "Send photo inline",
-                        f"inline:{service_key}:{token}",
-                    ),
-                )
-            ]
-            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-            return
-
-        if len(post.media_list) > 1:
-            preview_file_id = None
-            if first.type == "photo" and channel_id:
-                cache_key = build_media_cache_key(source_url, item_index=0, item_kind="photo")
-                preview_file_id = await deps.db.get_file_id(cache_key)
-                if not preview_file_id:
-                    try:
-                        sent = await deps.bot.send_photo(
-                            chat_id=channel_id,
-                            photo=first.url,
-                            caption=f"{service_name} Album Preview",
-                        )
-                        if sent.photo:
-                            preview_file_id = sent.photo[-1].file_id
-                            await deps.db.add_file(cache_key, preview_file_id, "photo")
-                    except Exception as exc:
-                        logging.warning(
-                            "Failed to cache %s album preview photo: url=%s error=%s",
-                            service_name,
-                            summarize_url_for_log(source_url),
-                            exc,
-                        )
-            token = create_inline_album_request(query.from_user.id, service_key, source_url)
-            deep_link = build_start_deeplink_url(bot_url, f"album_{token}")
-            results = [
-                build_inline_album_result(
-                    result_id=f"{service_key}_album_{post.id}",
-                    service_name=service_name,
-                    deep_link=deep_link,
-                    message_text=bm.captions(user_settings["captions"], post.description, bot_url),
-                    preview_file_id=preview_file_id,
-                    preview_url=first_preview,
-                    thumbnail_url=first_preview or get_inline_service_icon(service_key),
-                )
-            ]
-            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-            return
-
-        if first.type != "video":
-            if first_photo:
-                preview_url = get_preview_url(first_photo)
-                results = [
-                    types.InlineQueryResultPhoto(
-                    id=f"{service_key}_photo_{post.id}",
-                        photo_url=first_photo.url,
-                        thumbnail_url=preview_url,
-                        title=bm.inline_photo_title(service_name),
-                        description=post.description or bm.inline_photo_description(),
-                        caption=bm.captions(user_settings["captions"], post.description, bot_url),
-                        reply_markup=kb.return_video_info_keyboard(
-                            None, None, None, None, None, source_url, user_settings,
-                            audio_callback_data=None,
-                        ),
-                        parse_mode="HTML",
-                    )
-                ]
-                await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-                return
-
-            results = [
-                types.InlineQueryResultArticle(
-                    id=f"unsupported_{service_key}_content",
-                    title=f"{service_name} Content",
-                    description="Only single videos are supported inline.",
-                    input_message_content=types.InputTextMessageContent(
-                        message_text=f"Only single {service_name} videos are supported inline.",
-                    ),
-                )
-            ]
-            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-            return
-
-        token = create_inline_video_request(service_key, source_url, query.from_user.id, user_settings)
-        preview_url = get_preview_url(first) or get_inline_service_icon(service_key)
-        results = [
-            types.InlineQueryResultArticle(
-                id=f"{service_key}_inline:{token}",
-                title=f"{service_name} Video",
-                description=post.description or "Press the button to send this video inline.",
-                thumbnail_url=preview_url,
-                input_message_content=types.InputTextMessageContent(
-                    message_text=bm.inline_send_video_prompt(service_name),
-                ),
-                reply_markup=kb.inline_send_media_keyboard(
-                    "Send video inline",
-                    f"inline:{service_key}:{token}",
-                ),
-            )
-        ]
-        await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
-    except Exception as exc:
-        logging.exception(
-            "Error processing %s inline query: user_id=%s query=%s error=%s",
-            service_name,
-            query.from_user.id,
-            summarize_text_for_log(query.query),
-            exc,
-        )
-        await query.answer([], cache_time=1, is_personal=True)
+    await handle_post_inline_query(
+        query,
+        deps=deps,
+        service=pinterest_service,
+        url_regex=pinterest_url_regex,
+        strip_url_fn=strip_pinterest_url,
+        channel_id=channel_id,
+        service_key=service_key,
+        service_name=service_name,
+        analytics_action=analytics_action,
+        get_preview_url=get_preview_url,
+        allow_text_only=allow_text_only,
+        get_bot_url_fn=get_bot_url_fn,
+        safe_answer_inline_query_fn=safe_answer_inline_query_fn,
+        log=logging,
+    )
 
 
 async def send_inline_pinterest_media(
@@ -256,167 +68,21 @@ async def send_inline_pinterest_media(
     safe_edit_inline_media_fn=safe_edit_inline_media,
     safe_edit_inline_text_fn=safe_edit_inline_text,
 ) -> None:
-    request = claim_inline_video_request_for_send(
-        token,
-        duplicate_handler=duplicate_handler,
-        actor_user_id=actor_user_id,
-    )
-    if request is None:
-        return
-
-    download_path: Optional[str] = None
-
-    _edit_inline_status = build_inline_status_editor(
-        bot=deps.bot,
+    await send_inline_post_media(
+        token=token,
         inline_message_id=inline_message_id,
-        callback_data_factory=lambda _media_kind: f"inline:{service_key}:{token}",
+        actor_name=actor_name,
+        actor_user_id=actor_user_id,
+        request_event_id=request_event_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service=pinterest_service,
+        channel_id=channel_id,
+        max_file_size=max_file_size,
+        service_key=service_key,
+        service_name=service_name,
+        get_bot_url_fn=get_bot_url_fn,
+        safe_edit_inline_media_fn=safe_edit_inline_media_fn,
         safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        log=logging,
     )
-
-    try:
-        post = await pinterest_service.fetch_post(request.source_url)
-        if not post or len(post.media_list) != 1:
-            complete_inline_video_request(token)
-            await _edit_inline_status(bm.inline_photos_not_supported(service_name))
-            return
-
-        first_item = post.media_list[0]
-        if first_item.type == "photo":
-            cache_key = f"{request.source_url}#photo"
-            db_id = await deps.db.get_file_id(cache_key)
-            if not db_id:
-                if not channel_id:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-                sent = await deps.bot.send_photo(
-                    chat_id=channel_id,
-                    photo=first_item.url,
-                    caption=f"{service_name} Photo from {actor_name}",
-                )
-                if not sent.photo:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-                db_id = sent.photo[-1].file_id
-                await deps.db.add_file(cache_key, db_id, "photo")
-            else:
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-
-            bot_url = await get_bot_url_fn(deps.bot)
-            edited = await safe_edit_inline_media_fn(
-                deps.bot,
-                inline_message_id,
-                types.InputMediaPhoto(
-                    media=db_id,
-                    caption=bm.captions(request.user_settings["captions"], post.description, bot_url),
-                    parse_mode="HTML",
-                ),
-                reply_markup=kb.return_video_info_keyboard(
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    request.source_url,
-                    request.user_settings,
-                    audio_callback_data=None,
-                ),
-            )
-            if edited:
-                complete_inline_video_request(token)
-                return
-
-            reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-            return
-
-        if first_item.type != "video":
-            complete_inline_video_request(token)
-            await _edit_inline_status(bm.inline_photos_not_supported(service_name))
-            return
-
-        db_id = await deps.db.get_file_id(request.source_url)
-        if not db_id:
-            if not channel_id:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
-
-            timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-            filename = f"{post.id}_{timestamp}_{service_key}_inline.mp4"
-            await _edit_inline_status(bm.downloading_video_status())
-
-            on_progress = make_status_text_progress_updater(f"{service_name} video", _edit_inline_status)
-
-            metrics = await pinterest_service.download_media(
-                first_item.url,
-                filename,
-                user_id=request.owner_user_id,
-                request_id=f"{service_key}_inline:{request.owner_user_id}:{request_event_id}:{post.id}",
-                on_progress=on_progress,
-            )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
-
-            log_download_metrics(f"{service_key}_inline", metrics)
-            download_path = metrics.path
-            if metrics.size >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.video_too_large())
-                return
-
-            await _edit_inline_status(bm.uploading_status())
-            sent = await deps.bot.send_video(
-                chat_id=channel_id,
-                video=FSInputFile(download_path),
-                caption=f"{service_name} Video from {actor_name}",
-                **(await build_video_send_kwargs(download_path)),
-            )
-            db_id = sent.video.file_id
-            await deps.db.add_file(request.source_url, db_id, "video")
-        else:
-            await _edit_inline_status(bm.uploading_status())
-
-        bot_url = await get_bot_url_fn(deps.bot)
-        edited = await safe_edit_inline_media_fn(
-            deps.bot,
-            inline_message_id,
-            types.InputMediaVideo(
-                media=db_id,
-                caption=bm.captions(request.user_settings["captions"], post.description, bot_url),
-                parse_mode="HTML",
-            ),
-            reply_markup=kb.return_video_info_keyboard(
-                None,
-                None,
-                None,
-                None,
-                None,
-                request.source_url,
-                request.user_settings,
-                audio_callback_data=None,
-            ),
-        )
-        if edited:
-            complete_inline_video_request(token)
-            return
-
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    except DownloadRateLimitError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_rate_limit_text(exc.retry_after), with_retry_button=True)
-    except DownloadQueueBusyError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_queue_busy_text(exc.position), with_retry_button=True)
-    except Exception:
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    finally:
-        if download_path:
-            await remove_file(download_path)

--- a/handlers/settings_menu.py
+++ b/handlers/settings_menu.py
@@ -72,6 +72,16 @@ async def _ensure_settings_entities(
         )
 
 
+async def _resolve_settings_target(call: types.CallbackQuery) -> int | None:
+    if call.message and call.message.chat.type != "private":
+        is_admin = await user_mod._is_group_admin(call.message.chat.id, call.from_user.id)
+        if not is_admin:
+            await call.answer(bm.settings_admin_only(), show_alert=True)
+            return None
+        return call.message.chat.id
+    return call.from_user.id
+
+
 async def settings_menu(message: types.Message):
     await user_mod.send_analytics(user_id=message.from_user.id, chat_type=message.chat.type, action_name="settings")
     if message.chat.type != "private":
@@ -92,11 +102,8 @@ async def open_category(call: types.CallbackQuery):
         await call.answer()
         return
     cat = call.data.split(":", 1)[1]
-    if call.message and call.message.chat.type != "private":
-        is_admin = await user_mod._is_group_admin(call.message.chat.id, call.from_user.id)
-        if not is_admin:
-            await call.answer(bm.settings_admin_only(), show_alert=True)
-            return
+    if await _resolve_settings_target(call) is None:
+        return
     await call.message.edit_text(
         text=bm.category_settings_text(cat),
         reply_markup=kb.return_category_settings_keyboard(cat),
@@ -110,14 +117,9 @@ async def open_setting(call: types.CallbackQuery):
     if field is None:
         await call.answer(bm.invalid_settings_option(), show_alert=True)
         return
-    if call.message and call.message.chat.type != "private":
-        is_admin = await user_mod._is_group_admin(call.message.chat.id, call.from_user.id)
-        if not is_admin:
-            await call.answer(bm.settings_admin_only(), show_alert=True)
-            return
-        target_id = call.message.chat.id
-    else:
-        target_id = call.from_user.id
+    target_id = await _resolve_settings_target(call)
+    if target_id is None:
+        return
 
     try:
         await user_mod._ensure_settings_entities(call.message, call.from_user)
@@ -143,14 +145,9 @@ async def change_setting(call: types.CallbackQuery):
         await call.answer(bm.invalid_settings_option(), show_alert=True)
         return
     field, value = setting_payload
-    if call.message and call.message.chat.type != "private":
-        is_admin = await user_mod._is_group_admin(call.message.chat.id, call.from_user.id)
-        if not is_admin:
-            await call.answer(bm.settings_admin_only(), show_alert=True)
-            return
-        target_id = call.message.chat.id
-    else:
-        target_id = call.from_user.id
+    target_id = await _resolve_settings_target(call)
+    if target_id is None:
+        return
 
     try:
         await user_mod._ensure_settings_entities(call.message, call.from_user)

--- a/handlers/soundcloud.py
+++ b/handlers/soundcloud.py
@@ -24,6 +24,7 @@ from handlers.utils import (
     maybe_delete_user_message,
     react_to_message,
     remove_file,
+    register_inline_send_handlers,
     retry_async_operation,
     safe_delete_message,
     safe_edit_text,
@@ -32,8 +33,6 @@ from handlers.utils import (
     safe_answer_inline_query,
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
-    with_callback_logging,
-    with_chosen_inline_logging,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -63,6 +62,7 @@ from services.media.delivery import (
     coerce_audio_duration_seconds,
     send_audio_with_thumbnail,
 )
+from services.media.audio_flow import run_audio_flow
 from services.media.audio_metadata import build_audio_filename, prepare_mp3_metadata
 from services.platforms import soundcloud_media as soundcloud_platform
 
@@ -110,8 +110,6 @@ soundcloud_service = SoundCloudService(OUTPUT_DIR)
 @with_message_logging("soundcloud", "message")
 async def process_soundcloud(message: types.Message, direct_url: Optional[str] = None):
     status_message: Optional[types.Message] = None
-    audio_path: Optional[str] = None
-    prepared_metadata = None
     request_lease = None
     try:
         business_id = message.business_connection_id
@@ -154,110 +152,129 @@ async def process_soundcloud(message: types.Message, direct_url: Optional[str] =
             status_message = await message.answer(bm.downloading_audio_status())
 
         cache_key = build_audio_cache_key(source_url)
-        db_file_id = await db.get_file_id(cache_key)
-        track = None
-        if db_file_id:
-            await safe_edit_text(status_message, bm.uploading_status())
-            await send_chat_action_if_needed(
-                bot, message.chat.id, "upload_audio", business_id
-            )
-            await send_audio_with_thumbnail(
-                message.reply_audio,
-                audio=db_file_id,
-                caption=bm.captions(user_settings["captions"], None, bot_url),
-                bot_url=bot_url,
-                parse_mode="HTML",
-            )
-            await maybe_delete_user_message(message, user_settings["delete_message"])
-            request_lease.mark_success()
-            return
-
-        track = await soundcloud_service.fetch_track(source_url)
-        if not track:
-            await handle_download_error(message, business_id=business_id)
-            return
-
-        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        request_id = (
-            f"soundcloud_audio:{message.chat.id}:{message.message_id}:{track.id}"
-        )
-        audio_name = f"{track.id}_{timestamp}_soundcloud_audio.mp3"
+        track: Optional[SoundCloudTrack] = None
 
         async def _edit_status(text: str) -> None:
             await safe_edit_text(status_message, text)
 
-        on_progress = make_status_text_progress_updater(
-            "SoundCloud audio", _edit_status
-        )
-        on_retry = make_retry_status_notifier(
-            _edit_status,
-            enabled=show_service_status,
-        )
+        async def _send_cached(file_id: str):
+            await safe_edit_text(status_message, bm.uploading_status())
+            await send_chat_action_if_needed(
+                bot, message.chat.id, "upload_audio", business_id
+            )
+            return await send_audio_with_thumbnail(
+                message.reply_audio,
+                audio=file_id,
+                caption=bm.captions(user_settings["captions"], None, bot_url),
+                bot_url=bot_url,
+                parse_mode="HTML",
+            )
 
-        audio_metrics = await soundcloud_service.download_media(
-            track.audio_url,
-            audio_name,
-            user_id=message.from_user.id,
-            chat_id=message.chat.id,
-            request_id=request_id,
-            on_progress=on_progress,
-            on_retry=on_retry,
-        )
-        if not audio_metrics:
+        async def _fetch_track() -> bool:
+            nonlocal track
+            track = await soundcloud_service.fetch_track(source_url)
+            if not track:
+                await handle_download_error(message, business_id=business_id)
+                return False
+            return True
+
+        async def _download_audio():
+            timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            request_id = (
+                f"soundcloud_audio:{message.chat.id}:{message.message_id}:{track.id}"
+            )
+            audio_name = f"{track.id}_{timestamp}_soundcloud_audio.mp3"
+
+            on_progress = make_status_text_progress_updater(
+                "SoundCloud audio", _edit_status
+            )
+            on_retry = make_retry_status_notifier(
+                _edit_status,
+                enabled=show_service_status,
+            )
+
+            audio_metrics = await soundcloud_service.download_media(
+                track.audio_url,
+                audio_name,
+                user_id=message.from_user.id,
+                chat_id=message.chat.id,
+                request_id=request_id,
+                on_progress=on_progress,
+                on_retry=on_retry,
+            )
+            if audio_metrics:
+                log_download_metrics("soundcloud_audio", audio_metrics)
+            return audio_metrics
+
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(
+                path,
+                {
+                    "title": track.title,
+                    "artists": track.artist,
+                    "thumbnail": track.thumbnail_url,
+                    "source_url": source_url,
+                },
+            )
+
+        async def _send_downloaded(path: str, prepared_metadata):
+            await safe_edit_text(status_message, bm.uploading_status())
+            await send_chat_action_if_needed(
+                bot, message.chat.id, "upload_audio", business_id
+            )
+
+            audio_thumbnail = (
+                FSInputFile(str(prepared_metadata.thumbnail_path), filename="cover.jpg")
+                if prepared_metadata.thumbnail_path
+                else bot_avatar
+            )
+            return await send_audio_with_thumbnail(
+                message.reply_audio,
+                audio=FSInputFile(
+                    path,
+                    filename=build_audio_filename(track.title),
+                ),
+                title=track.title,
+                performer=track.artist or None,
+                caption=bm.captions(user_settings["captions"], None, bot_url),
+                audio_path=path,
+                bot_avatar=audio_thumbnail,
+                bot_url=bot_url,
+                duration=track.duration_seconds,
+                embed_thumbnail=False,
+                parse_mode="HTML",
+            )
+
+        async def _after_send(_result):
+            await maybe_delete_user_message(message, user_settings["delete_message"])
+            request_lease.mark_success()
+
+        async def _on_missing_audio():
             await handle_download_error(message, business_id=business_id)
-            return
 
-        log_download_metrics("soundcloud_audio", audio_metrics)
-        audio_path = audio_metrics.path
-        if audio_metrics.size >= MAX_FILE_SIZE:
+        async def _on_too_large():
             await message.reply(bm.audio_too_large())
-            return
 
-        prepared_metadata = await prepare_mp3_metadata(
-            audio_path,
-            {
-                "title": track.title,
-                "artists": track.artist,
-                "thumbnail": track.thumbnail_url,
-                "source_url": source_url,
-            },
-        )
-
-        await safe_edit_text(status_message, bm.uploading_status())
-        await send_chat_action_if_needed(
-            bot, message.chat.id, "upload_audio", business_id
-        )
-
-        audio_thumbnail = (
-            FSInputFile(str(prepared_metadata.thumbnail_path), filename="cover.jpg")
-            if prepared_metadata.thumbnail_path
-            else bot_avatar
-        )
-        sent = await send_audio_with_thumbnail(
-            message.reply_audio,
-            audio=FSInputFile(
-                audio_path,
-                filename=build_audio_filename(track.title),
-            ),
-            title=track.title,
-            performer=track.artist or None,
-            caption=bm.captions(user_settings["captions"], None, bot_url),
-            audio_path=audio_path,
-            bot_avatar=audio_thumbnail,
-            bot_url=bot_url,
-            duration=track.duration_seconds,
-            embed_thumbnail=False,
-            parse_mode="HTML",
-        )
-
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-        request_lease.mark_success()
-        try:
-            await db.add_file(cache_key, sent.audio.file_id, "audio")
-        except Exception as exc:
+        async def _on_cache_store_error(exc: Exception) -> None:
             logging.error(
                 "Error caching SoundCloud audio: key=%s error=%s", cache_key, exc
             )
+
+        await run_audio_flow(
+            cache_key=cache_key,
+            db_service=db,
+            send_cached=_send_cached,
+            fetch_metadata=_fetch_track,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=MAX_FILE_SIZE,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+            on_cache_store_error=_on_cache_store_error,
+            on_after_send=_after_send,
+        )
 
     except (DownloadRateLimitError, DownloadQueueBusyError) as exc:
         show_service_status = message.business_connection_id is None
@@ -271,10 +288,6 @@ async def process_soundcloud(message: types.Message, direct_url: Optional[str] =
         if request_lease is not None:
             request_lease.finish()
         await safe_delete_message(status_message)
-        if audio_path:
-            await remove_file(audio_path)
-        if prepared_metadata:
-            prepared_metadata.cleanup()
         await update_info(message)
 
 
@@ -361,9 +374,6 @@ async def _send_inline_soundcloud_audio(
     if request is None:
         return
 
-    audio_path: Optional[str] = None
-    prepared_metadata = None
-
     async def _edit_inline_status(
         text: str, *, with_retry_button: bool = False
     ) -> None:
@@ -389,8 +399,11 @@ async def _send_inline_soundcloud_audio(
             await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
             return
 
-        db_file_id = await db.get_file_id(cache_key)
-        if not db_file_id:
+        async def _send_cached(_file_id: str):
+            await _edit_inline_status(bm.uploading_status())
+            return None
+
+        async def _download_audio():
             timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
             request_id = f"soundcloud_inline:{request.owner_user_id}:{request_event_id}:{track.id}"
             audio_name = f"{track.id}_{timestamp}_soundcloud_inline.mp3"
@@ -401,28 +414,27 @@ async def _send_inline_soundcloud_audio(
                 "SoundCloud audio", _edit_inline_status
             )
 
-            metrics = await soundcloud_service.download_media(
+            return await soundcloud_service.download_media(
                 track.audio_url,
                 audio_name,
                 user_id=request.owner_user_id,
                 request_id=request_id,
                 on_progress=on_progress,
             )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(
-                    bm.something_went_wrong(), with_retry_button=True
-                )
-                return
 
-            audio_path = metrics.path
-            if metrics.size >= MAX_FILE_SIZE:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.audio_too_large())
-                return
+        async def _on_missing_audio():
+            reset_inline_video_request(token)
+            await _edit_inline_status(
+                bm.something_went_wrong(), with_retry_button=True
+            )
 
-            prepared_metadata = await prepare_mp3_metadata(
-                audio_path,
+        async def _on_too_large():
+            complete_inline_video_request(token)
+            await _edit_inline_status(bm.audio_too_large())
+
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(
+                path,
                 {
                     "title": track.title,
                     "artists": track.artist,
@@ -431,38 +443,49 @@ async def _send_inline_soundcloud_audio(
                 },
             )
 
+        async def _send_downloaded(path: str, prepared_metadata):
             await _edit_inline_status(bm.uploading_status())
             audio_thumbnail = (
                 FSInputFile(str(prepared_metadata.thumbnail_path), filename="cover.jpg")
                 if prepared_metadata.thumbnail_path
                 else bot_avatar
             )
-            sent = await send_audio_with_thumbnail(
+            return await send_audio_with_thumbnail(
                 bot.send_audio,
                 chat_id=CHANNEL_ID,
                 audio=FSInputFile(
-                    audio_path,
+                    path,
                     filename=build_audio_filename(track.title),
                 ),
                 title=track.title,
                 performer=track.artist or None,
-                audio_path=audio_path,
+                audio_path=path,
                 bot_avatar=audio_thumbnail,
                 bot_url=bot_url,
                 duration=track.duration_seconds,
                 embed_thumbnail=False,
             )
 
-            db_file_id = sent.audio.file_id
-            await db.add_file(cache_key, db_file_id, "audio")
-        else:
-            await _edit_inline_status(bm.uploading_status())
+        result = await run_audio_flow(
+            cache_key=cache_key,
+            db_service=db,
+            send_cached=_send_cached,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=MAX_FILE_SIZE,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+        )
+        if result is None:
+            return
 
         edited = await safe_edit_inline_media(
             bot,
             inline_message_id,
             types.InputMediaAudio(
-                media=db_file_id,
+                media=result.file_id,
                 caption=bm.captions(request.user_settings["captions"], None, bot_url),
                 performer=track.artist or build_bot_audio_performer(bot_url),
                 duration=coerce_audio_duration_seconds(track.duration_seconds),
@@ -488,56 +511,19 @@ async def _send_inline_soundcloud_audio(
     except Exception:
         reset_inline_video_request(token)
         await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    finally:
-        if prepared_metadata:
-            prepared_metadata.cleanup()
-        if audio_path:
-            await remove_file(audio_path)
 
 
-@router.chosen_inline_result(F.result_id.startswith("soundcloud_inline:"))
-@with_chosen_inline_logging("soundcloud", "chosen_inline")
-async def chosen_inline_soundcloud_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning("Chosen inline SoundCloud result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("soundcloud_inline:")
-    await _send_inline_soundcloud_audio(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_soundcloud_result, send_inline_soundcloud_audio_callback = (
+    register_inline_send_handlers(
+        router,
+        service="soundcloud",
+        result_prefix="soundcloud_inline:",
+        callback_prefix="inline:soundcloud:",
+        send_fn=_send_inline_soundcloud_audio,
+        missing_inline_message_warning=(
+            "Chosen inline SoundCloud result is missing inline_message_id"
+        ),
+        chosen_handler_name="chosen_inline_soundcloud_result",
+        callback_handler_name="send_inline_soundcloud_audio_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:soundcloud:"))
-@with_callback_logging("soundcloud", "inline_callback")
-async def send_inline_soundcloud_audio_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:soundcloud:")
-    await call.answer()
-    try:
-        await _send_inline_soundcloud_audio(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
+)

--- a/handlers/spotify.py
+++ b/handlers/spotify.py
@@ -31,6 +31,7 @@ from handlers.utils import (
 )
 from handlers.youtube import download_mp3_with_ytdlp_metrics, search_youtube_track
 from services.logger import logger as logging, summarize_url_for_log
+from services.media.audio_flow import run_audio_flow
 from services.media.audio_metadata import (
     build_audio_filename,
     prepare_mp3_metadata,
@@ -80,8 +81,6 @@ async def process_spotify(message: types.Message, direct_url: Optional[str] = No
     business_id = message.business_connection_id
     show_service_status = business_id is None
     status_message: Optional[types.Message] = None
-    audio_path: str | None = None
-    prepared_metadata = None
     request_lease = None
     try:
         if await should_skip_duplicate_business_message(
@@ -111,81 +110,102 @@ async def process_spotify(message: types.Message, direct_url: Optional[str] = No
             status_message = await message.answer(bm.downloading_audio_status())
 
         cache_key = build_audio_cache_key(source_url)
-        db_file_id = await db.get_file_id(cache_key)
-        if db_file_id:
+        track: dict | None = None
+        youtube_track: dict | None = None
+
+        async def _send_cached(file_id: str):
             await safe_edit_text(status_message, bm.uploading_status())
             await send_chat_action_if_needed(
                 bot, message.chat.id, "upload_audio", business_id
             )
-            await message.reply_audio(
-                audio=db_file_id,
+            return await message.reply_audio(
+                audio=file_id,
                 caption=bm.captions(user_settings["captions"], None, bot_url),
                 parse_mode="HTML",
             )
+
+        async def _fetch_track() -> bool:
+            nonlocal track, youtube_track
+            track = await get_spotify_track(source_url)
+            query = " - ".join(
+                value
+                for value in (track.get("artists"), track.get("title"))
+                if value and value != "Unknown artist"
+            )
+            youtube_track = await asyncio.to_thread(search_youtube_track, query)
+            if not youtube_track or not youtube_track.get("webpage_url"):
+                await message.reply(bm.spotify_source_not_found())
+                return False
+            return True
+
+        async def _download_audio():
+            base_name = f"{track['spotify_id']}_spotify_audio"
+            return await retry_async_operation(
+                lambda: download_mp3_with_ytdlp_metrics(
+                    youtube_track["webpage_url"],
+                    base_name,
+                    "spotify_audio_mp3",
+                    max_filesize=MAX_FILE_SIZE - 1,
+                ),
+                attempts=3,
+                delay_seconds=2.0,
+                should_retry_result=lambda result: result is None,
+            )
+
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(path, track)
+
+        async def _send_downloaded(path: str, prepared_metadata):
+            await safe_edit_text(status_message, bm.uploading_status())
+            await send_chat_action_if_needed(
+                bot, message.chat.id, "upload_audio", business_id
+            )
+            thumbnail = (
+                FSInputFile(str(prepared_metadata.thumbnail_path), filename="cover.jpg")
+                if prepared_metadata.thumbnail_path
+                else await get_bot_avatar_thumbnail(bot)
+            )
+            return await send_audio_with_thumbnail(
+                message.reply_audio,
+                audio=FSInputFile(
+                    path,
+                    filename=build_audio_filename(track.get("title")),
+                ),
+                title=track.get("title"),
+                performer=track.get("artists"),
+                caption=bm.captions(user_settings["captions"], None, bot_url),
+                audio_path=path,
+                bot_avatar=thumbnail,
+                bot_url=bot_url,
+                duration=track.get("duration"),
+                embed_thumbnail=False,
+                parse_mode="HTML",
+            )
+
+        async def _after_send(_result):
             await maybe_delete_user_message(message, user_settings["delete_message"])
             request_lease.mark_success()
-            return
 
-        track = await get_spotify_track(source_url)
-        query = " - ".join(
-            value
-            for value in (track.get("artists"), track.get("title"))
-            if value and value != "Unknown artist"
-        )
-        youtube_track = await asyncio.to_thread(search_youtube_track, query)
-        if not youtube_track or not youtube_track.get("webpage_url"):
-            await message.reply(bm.spotify_source_not_found())
-            return
-
-        base_name = f"{track['spotify_id']}_spotify_audio"
-        metrics = await retry_async_operation(
-            lambda: download_mp3_with_ytdlp_metrics(
-                youtube_track["webpage_url"],
-                base_name,
-                "spotify_audio_mp3",
-                max_filesize=MAX_FILE_SIZE - 1,
-            ),
-            attempts=3,
-            delay_seconds=2.0,
-            should_retry_result=lambda result: result is None,
-        )
-        if not metrics:
+        async def _on_missing_audio():
             await handle_download_error(message, business_id=business_id)
-            return
-        audio_path = metrics.path
-        if metrics.size >= MAX_FILE_SIZE:
-            await message.reply(bm.audio_too_large())
-            return
 
-        prepared_metadata = await prepare_mp3_metadata(audio_path, track)
-        await safe_edit_text(status_message, bm.uploading_status())
-        await send_chat_action_if_needed(
-            bot, message.chat.id, "upload_audio", business_id
+        async def _on_too_large():
+            await message.reply(bm.audio_too_large())
+
+        await run_audio_flow(
+            cache_key=cache_key,
+            db_service=db,
+            send_cached=_send_cached,
+            fetch_metadata=_fetch_track,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=MAX_FILE_SIZE,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+            on_after_send=_after_send,
         )
-        thumbnail = (
-            FSInputFile(str(prepared_metadata.thumbnail_path), filename="cover.jpg")
-            if prepared_metadata.thumbnail_path
-            else await get_bot_avatar_thumbnail(bot)
-        )
-        sent = await send_audio_with_thumbnail(
-            message.reply_audio,
-            audio=FSInputFile(
-                audio_path,
-                filename=build_audio_filename(track.get("title")),
-            ),
-            title=track.get("title"),
-            performer=track.get("artists"),
-            caption=bm.captions(user_settings["captions"], None, bot_url),
-            audio_path=audio_path,
-            bot_avatar=thumbnail,
-            bot_url=bot_url,
-            duration=track.get("duration"),
-            embed_thumbnail=False,
-            parse_mode="HTML",
-        )
-        await db.add_file(cache_key, sent.audio.file_id, "audio")
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-        request_lease.mark_success()
     except SpotifyError as exc:
         logging.warning("Spotify metadata error: url=%s error=%s", source_url, exc)
         await message.reply(bm.spotify_metadata_failed())
@@ -207,10 +227,6 @@ async def process_spotify(message: types.Message, direct_url: Optional[str] = No
         if request_lease is not None:
             request_lease.finish()
         await safe_delete_message(status_message)
-        if audio_path:
-            await remove_file(audio_path)
-        if prepared_metadata:
-            prepared_metadata.cleanup()
         await update_info(message)
 
 

--- a/handlers/threads.py
+++ b/handlers/threads.py
@@ -27,6 +27,7 @@ from handlers.utils import (
     maybe_delete_user_message,
     react_to_message,
     remove_file,
+    register_inline_send_handlers,
     retry_async_operation,
     safe_delete_message,
     safe_answer_inline_query,
@@ -35,16 +36,17 @@ from handlers.utils import (
     safe_edit_text,
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
-    with_callback_logging,
-    with_chosen_inline_logging,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
 )
 from services.logger import logger as logging, summarize_text_for_log, summarize_url_for_log
 from services.media.delivery import send_cached_media_entries
-from services.media.orchestration import handle_download_backpressure, run_single_media_flow
-from services.media.resolver import resolve_cached_media_items
+from services.media.orchestration import (
+    make_message_backpressure_handler,
+    run_media_group_flow,
+    run_single_media_flow,
+)
 from services.media.video_metadata import build_video_send_kwargs
 from services.platforms.threads_media import (
     DownloadError,
@@ -243,14 +245,13 @@ async def process_threads_single_media(
             return False
         return True
 
-    async def _handle_backpressure(exc: Exception) -> None:
-        await handle_download_backpressure(
-            exc,
-            business_id=business_id,
-            on_rate_limit_reply=lambda retry_after: message.reply(build_rate_limit_text(retry_after)),
-            on_queue_busy_reply=lambda position: message.reply(build_queue_busy_text(position)),
-            on_business_error=lambda: handle_download_error(message, business_id=business_id),
-        )
+    _handle_backpressure = make_message_backpressure_handler(
+        message,
+        business_id,
+        build_rate_limit_text=build_rate_limit_text,
+        build_queue_busy_text=build_queue_busy_text,
+        handle_download_error=handle_download_error,
+    )
 
     sent = await run_single_media_flow(
         cache_key=cache_key,
@@ -303,23 +304,7 @@ async def process_threads_media_group(
             request_id=request_id,
         )
 
-    media_items, downloaded_paths = await resolve_cached_media_items(
-        post.media_list,
-        db_service=db,
-        kind_getter=lambda item: item.type,
-        build_cache_key=lambda index, _item, media_kind: build_media_cache_key(
-            source_url, item_index=index, item_kind=media_kind
-        ),
-        download_item=_download_item,
-        metrics_label="threads_group",
-        error_label="Threads",
-    )
-    if not media_items:
-        await handle_download_error(message, business_id=business_id)
-        return False
-
-    try:
-        await safe_edit_text(status_message, bm.uploading_status())
+    async def _send_entries(media_items: list[dict]) -> None:
         await send_cached_media_entries(
             message,
             media_items,
@@ -329,12 +314,25 @@ async def process_threads_media_group(
             parse_mode="HTML",
             kind_key="type",
         )
-        await maybe_delete_user_message(message, user_settings["delete_message"])
-        return True
-    finally:
-        await safe_delete_message(status_message)
-        for path in downloaded_paths:
-            await remove_file(path)
+
+    return await run_media_group_flow(
+        media_list=post.media_list,
+        db_service=db,
+        kind_getter=lambda item: item.type,
+        build_cache_key=lambda index, _item, media_kind: build_media_cache_key(
+            source_url, item_index=index, item_kind=media_kind
+        ),
+        download_item=_download_item,
+        metrics_label="threads_group",
+        error_label="Threads",
+        update_status=lambda text: safe_edit_text(status_message, text),
+        upload_status_text=bm.uploading_status(),
+        send_entries=_send_entries,
+        on_empty=lambda: handle_download_error(message, business_id=business_id),
+        delete_status_message=lambda: safe_delete_message(status_message),
+        cleanup_path=remove_file,
+        on_after_send=lambda: maybe_delete_user_message(message, user_settings["delete_message"]),
+    )
 
 
 @router.inline_query(F.query.regexp(THREADS_URL_REGEX, mode="search"))
@@ -388,46 +386,17 @@ async def _send_inline_threads_media(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("threads_inline:"))
-@with_chosen_inline_logging("threads", "chosen_inline")
-async def chosen_inline_threads_result(result: types.ChosenInlineResult) -> None:
-    if not result.inline_message_id:
-        logging.warning("Chosen inline Threads result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("threads_inline:")
-    await _send_inline_threads_media(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_threads_result, send_inline_threads_media_callback = (
+    register_inline_send_handlers(
+        router,
+        service="threads",
+        result_prefix="threads_inline:",
+        callback_prefix="inline:threads:",
+        send_fn=_send_inline_threads_media,
+        missing_inline_message_warning=(
+            "Chosen inline Threads result is missing inline_message_id"
+        ),
+        chosen_handler_name="chosen_inline_threads_result",
+        callback_handler_name="send_inline_threads_media_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:threads:"))
-@with_callback_logging("threads", "inline_callback")
-async def send_inline_threads_media_callback(call: types.CallbackQuery) -> None:
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:threads:")
-    await call.answer()
-    try:
-        await _send_inline_threads_media(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-        elif str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
+)

--- a/handlers/tiktok.py
+++ b/handlers/tiktok.py
@@ -20,10 +20,10 @@ from handlers.request_dedupe import claim_message_request
 from handlers.tiktok_inline import handle_tiktok_inline_query, send_inline_tiktok_media
 from services.media.delivery import (
     build_audio_cache_key,
+    make_video_or_document_senders,
     send_audio_with_thumbnail,
     send_cached_media_entries,
 )
-from services.media.video_metadata import build_video_send_kwargs
 from services.media.orchestration import run_single_media_flow
 from handlers.user import update_info
 from handlers.utils import (
@@ -35,6 +35,7 @@ from handlers.utils import (
     handle_video_too_large,
     should_skip_duplicate_business_message,
     load_user_settings,
+    make_backpressure_handler,
     make_retry_status_notifier,
     make_status_text_progress_updater,
     maybe_delete_user_message,
@@ -47,8 +48,7 @@ from handlers.utils import (
     safe_answer_inline_query,
     send_chat_action_if_needed,
     retry_async_operation,
-    with_callback_logging,
-    with_chosen_inline_logging,
+    register_inline_send_handlers,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -164,7 +164,7 @@ async def process_tiktok(message: types.Message, direct_url: Optional[str] = Non
 
         # Profile lookup: allow messages like "@username" without a URL.
         if direct_url is None and re.fullmatch(r"@[\w.]{1,32}", stripped):
-            await react_to_message(message, "рџ‘ѕ", business_id=business_id)
+            await react_to_message(message, "👾", business_id=business_id)
             settings = await load_user_settings(db, message)
             await process_tiktok_profile(
                 message, stripped, bot_url, settings["captions"]
@@ -246,9 +246,11 @@ async def process_tiktok_video(
     bot_url: str,
     user_settings: dict,
     business_id: Optional[int],
+    actor_user_id: Optional[int] = None,
 ):
+    actor_id = actor_user_id or message.from_user.id
     await send_analytics(
-        user_id=message.from_user.id,
+        user_id=actor_id,
         chat_type=message.chat.type,
         action_name="tiktok_video",
     )
@@ -256,7 +258,7 @@ async def process_tiktok_video(
     if not info:
         logging.warning(
             "TikTok video metadata missing: user_id=%s data_keys=%s",
-            message.from_user.id,
+            actor_id,
             list(data.keys()),
         )
         await handle_download_error(message, business_id=business_id)
@@ -317,7 +319,7 @@ async def process_tiktok_video(
                 db_video_url,
                 download_name,
                 download_data=data,
-                user_id=message.from_user.id,
+                user_id=actor_id,
                 chat_id=message.chat.id,
                 request_id=request_id,
                 size_hint=size_hint,
@@ -327,50 +329,14 @@ async def process_tiktok_video(
             timeout=420.0,
         )
 
-    async def _send_cached(file_id: str):
-        logging.info(
-            "Serving cached TikTok video: url=%s file_id=%s",
-            summarize_url_for_log(db_video_url),
-            file_id,
-        )
-        try:
-            if as_document:
-                return await message.reply_document(
-                    document=file_id,
-                    caption=bm.captions(
-                        user_settings["captions"], info.description, bot_url
-                    ),
-                    reply_markup=_reply_markup(),
-                    parse_mode="HTML",
-                    disable_content_type_detection=True,
-                )
-            return await message.reply_video(
-                video=file_id,
-                caption=bm.captions(
-                    user_settings["captions"], info.description, bot_url
-                ),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
-            )
-        except TelegramBadRequest:
-            return None
-
-    async def _send_downloaded(path: str):
-        if as_document:
-            return await message.reply_document(
-                document=FSInputFile(path),
-                caption=bm.captions(user_settings["captions"], info.description, bot_url),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
-                disable_content_type_detection=True,
-            )
-        return await message.reply_video(
-            video=FSInputFile(path),
-            caption=bm.captions(user_settings["captions"], info.description, bot_url),
-            reply_markup=_reply_markup(),
-            parse_mode="HTML",
-            **(await build_video_send_kwargs(path)),
-        )
+    _send_cached, _send_downloaded, _extract_file_id = make_video_or_document_senders(
+        message,
+        caption=bm.captions(user_settings["captions"], info.description, bot_url),
+        reply_markup_fn=_reply_markup,
+        as_document=as_document,
+        cached_log_label="TikTok video",
+        cached_log_url=db_video_url,
+    )
 
     async def _after_send():
         await maybe_delete_user_message(message, user_settings["delete_message"])
@@ -387,12 +353,7 @@ async def process_tiktok_video(
             return False
         return True
 
-    async def _handle_backpressure(exc: Exception) -> None:
-        await handle_download_backpressure_error(
-            exc,
-            message=message,
-            show_service_status=business_id is None,
-        )
+    _handle_backpressure = make_backpressure_handler(message, business_id)
 
     async def _handle_unexpected_error(exc: Exception) -> None:
         if isinstance(exc, asyncio.TimeoutError):
@@ -424,9 +385,7 @@ async def process_tiktok_video(
         send_cached=_send_cached,
         download_media=_download_media,
         send_downloaded=_send_downloaded,
-        extract_file_id=lambda sent: (
-            sent.document.file_id if getattr(sent, "document", None) else (sent.video.file_id if getattr(sent, "video", None) else None)
-        ),
+        extract_file_id=_extract_file_id,
         cleanup_path=remove_file,
         delete_status_message=lambda: safe_delete_message(status_message),
         on_missing_media=lambda: handle_download_error(
@@ -484,19 +443,27 @@ async def process_tiktok_photos(
 
         if as_document and len(images) > 1:
             from utils.zip_utils import create_photos_zip
-            photo_paths = []
-            for index, image_url in enumerate(images):
+
+            async def _download_zip_photo(index: int, image_url: str) -> Optional[str]:
                 download_name = f"{index}_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}_photo.jpg"
                 try:
-                    path = await tiktok_service.download_media(
+                    return await tiktok_service.download_media(
                         image_url,
                         download_name,
                         user_id=message.from_user.id,
                         chat_id=message.chat.id,
                     )
-                    photo_paths.append(path)
                 except Exception as exc:
                     logging.warning("Failed to download TikTok photo for ZIP: %s", exc)
+                    return None
+
+            downloaded_paths = await asyncio.gather(
+                *(
+                    _download_zip_photo(index, image_url)
+                    for index, image_url in enumerate(images)
+                )
+            )
+            photo_paths = [path for path in downloaded_paths if path]
 
             if photo_paths:
                 zip_name = f"tiktok_photos_{info.id if info else datetime.datetime.now().strftime('%Y%m%d%H%M%S')}.zip"
@@ -526,22 +493,28 @@ async def process_tiktok_photos(
                 await maybe_delete_user_message(message, user_settings["delete_message"] if isinstance(user_settings, dict) else "off")
                 return True
 
-        media_items = []
-        for index, image_url in enumerate(images):
-            cache_key = build_media_cache_key(
+        cache_keys = [
+            build_media_cache_key(
                 video_url or image_url, item_index=index, item_kind="photo"
             )
-            cached_file_id = await db.get_file_id(cache_key)
-            media_items.append(
-                {
-                    "index": index,
-                    "kind": "photo",
-                    "cache_key": cache_key,
-                    "file_id": cached_file_id,
-                    "url": image_url,
-                    "cached": bool(cached_file_id),
-                }
+            for index, image_url in enumerate(images)
+        ]
+        cached_file_ids = await asyncio.gather(
+            *(db.get_file_id(cache_key) for cache_key in cache_keys)
+        )
+        media_items = [
+            {
+                "index": index,
+                "kind": "photo",
+                "cache_key": cache_key,
+                "file_id": cached_file_id,
+                "url": image_url,
+                "cached": bool(cached_file_id),
+            }
+            for index, (image_url, cache_key, cached_file_id) in enumerate(
+                zip(images, cache_keys, cached_file_ids)
             )
+        ]
 
         await send_cached_media_entries(
             message,
@@ -652,7 +625,14 @@ async def download_tiktok_doc_callback(call: types.CallbackQuery):
     video_url = f"https://www.tiktok.com/@i/video/{video_id}"
     try:
         data = await fetch_tiktok_data_with_retry(video_url)
-        user_settings = await load_user_settings(db, call.message)
+        # call.message is authored by the bot, so resolve settings from the
+        # pressing user (or the group chat), not from the message author.
+        settings_target_id = (
+            call.message.chat.id
+            if call.message.chat and call.message.chat.type != "private"
+            else call.from_user.id
+        )
+        user_settings = await db.user_settings(settings_target_id)
         override_settings = dict(user_settings)
         override_settings["as_document"] = "on"
         await process_tiktok_video(
@@ -661,6 +641,7 @@ async def download_tiktok_doc_callback(call: types.CallbackQuery):
             await get_bot_url(bot),
             override_settings,
             call.message.business_connection_id,
+            actor_user_id=call.from_user.id,
         )
     except Exception as exc:
         logging.error("Failed to process doc:tiktok callback: video_id=%s error=%s", video_id, exc)
@@ -846,57 +827,20 @@ async def _send_inline_tiktok_video(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("tiktok_inline:"))
-@with_chosen_inline_logging("tiktok", "chosen_inline")
-async def chosen_inline_tiktok_result(result: types.ChosenInlineResult):
-    inline_message_id = result.inline_message_id
-    if not inline_message_id:
-        logging.warning(
+chosen_inline_tiktok_result, send_inline_tiktok_video_callback = (
+    register_inline_send_handlers(
+        router,
+        service="tiktok",
+        result_prefix="tiktok_inline:",
+        callback_prefix="inline:tiktok:",
+        send_fn=_send_inline_tiktok_video,
+        missing_inline_message_warning=(
             "Chosen inline TikTok result is missing inline_message_id; enable inline feedback in BotFather"
-        )
-        return
-
-    token = result.result_id.removeprefix("tiktok_inline:")
-    await _send_inline_tiktok_video(
-        token=token,
-        inline_message_id=inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+        ),
+        chosen_handler_name="chosen_inline_tiktok_result",
+        callback_handler_name="send_inline_tiktok_video_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:tiktok:"))
-@with_callback_logging("tiktok", "inline_callback")
-async def send_inline_tiktok_video_callback(call: types.CallbackQuery):
-    token = call.data.removeprefix("inline:tiktok:")
-    inline_message_id = call.inline_message_id
-    if not inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    await call.answer()
-    try:
-        await _send_inline_tiktok_video(
-            token=token,
-            inline_message_id=inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
-        await call.answer(bm.something_went_wrong(), show_alert=True)
+)
 
 
 @router.callback_query(

--- a/handlers/tiktok_inline.py
+++ b/handlers/tiktok_inline.py
@@ -4,36 +4,34 @@ import re
 from typing import Optional
 
 from aiogram import types
-from aiogram.types import FSInputFile, InlineQueryResultArticle
+from aiogram.types import InlineQueryResultArticle
 
 import keyboards as kb
 import messages as bm
 from handlers.deps import HandlerDependencies
 from handlers.utils import (
     build_inline_album_result,
-    build_inline_status_editor,
-    build_queue_busy_text,
-    build_rate_limit_text,
     build_start_deeplink_url,
     get_bot_url,
     make_retry_status_notifier,
-    make_status_text_progress_updater,
-    remove_file,
     safe_answer_inline_query,
     safe_edit_inline_media,
     safe_edit_inline_text,
 )
-from services.logger import logger as logging, summarize_text_for_log, summarize_url_for_log
+from services.logger import logger as logging, summarize_text_for_log
 from services.inline.album_links import create_inline_album_request
+from services.inline.send_flow import (
+    deliver_inline_photo,
+    deliver_inline_video,
+    ensure_album_preview_file_id,
+    run_inline_send_flow,
+)
 from services.inline.service_icons import get_inline_service_icon
 from services.inline.video_requests import (
-    claim_inline_video_request_for_send,
     complete_inline_video_request,
     create_inline_video_request,
     reset_inline_video_request,
 )
-from services.media.video_metadata import build_video_send_kwargs
-from utils.download_manager import DownloadQueueBusyError, DownloadRateLimitError, log_download_metrics
 from utils.media_cache import build_media_cache_key
 
 logging = logging.bind(service="tiktok_inline")
@@ -140,30 +138,19 @@ async def handle_tiktok_inline_query(
 
             token = create_inline_album_request(query.from_user.id, "tiktok", source_url)
             deep_link = build_start_deeplink_url(bot_url, f"album_{token}")
-            preview_file_id = None
-            if channel_id:
-                preview_cache_key = build_media_cache_key(
+            preview_file_id = await ensure_album_preview_file_id(
+                deps=deps,
+                channel_id=channel_id,
+                photo_url=first_photo,
+                cache_key=build_media_cache_key(
                     build_tiktok_video_url_fn(info) if info else source_url,
                     item_index=0,
                     item_kind="photo",
-                )
-                preview_file_id = await deps.db.get_file_id(preview_cache_key)
-                if not preview_file_id:
-                    try:
-                        sent = await deps.bot.send_photo(
-                            chat_id=channel_id,
-                            photo=first_photo,
-                            caption="TikTok Album Preview",
-                        )
-                        if sent.photo:
-                            preview_file_id = sent.photo[-1].file_id
-                            await deps.db.add_file(preview_cache_key, preview_file_id, "photo")
-                    except Exception as exc:
-                        logging.warning(
-                            "Failed to cache TikTok album preview photo: url=%s error=%s",
-                            summarize_url_for_log(source_url),
-                            exc,
-                        )
+                ),
+                service_name="TikTok",
+                source_url=source_url,
+                log=logging,
+            )
             results.append(build_inline_album_result(
                 result_id=f"tiktok_album_{info.id if info else token}",
                 service_name="TikTok",
@@ -209,74 +196,42 @@ async def send_inline_tiktok_media(
     safe_edit_inline_media_fn=safe_edit_inline_media,
     safe_edit_inline_text_fn=safe_edit_inline_text,
 ) -> None:
-    request = claim_inline_video_request_for_send(
-        token,
-        duplicate_handler=duplicate_handler,
-        actor_user_id=actor_user_id,
-    )
-    if request is None:
-        return
-
-    download_path: Optional[str] = None
-
-    _edit_inline_status = build_inline_status_editor(
-        bot=deps.bot,
-        inline_message_id=inline_message_id,
-        callback_data_factory=lambda _media_kind: f"inline:tiktok:{token}",
-        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
-    )
-
-    try:
+    async def _plan(request, edit_status, state) -> None:
         async def _on_retry_fetch(failed_attempt: int, total_attempts: int, _error):
             if failed_attempt >= 2:
-                await _edit_inline_status(bm.retrying_again_status(failed_attempt + 1, total_attempts))
+                await edit_status(bm.retrying_again_status(failed_attempt + 1, total_attempts))
 
         data = await fetch_tiktok_data_with_retry_fn(request.source_url, on_retry=_on_retry_fetch)
         info = await video_info_fn(data)
         images = data.get("data", {}).get("images", [])
         if not info:
             reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True)
             return
         if len(images) > 1:
             complete_inline_video_request(token)
-            await _edit_inline_status(bm.inline_photos_not_supported("TikTok"))
+            await edit_status(bm.inline_photos_not_supported("TikTok"))
             return
+
+        async def _build_caption():
+            return bm.captions(
+                request.user_settings["captions"],
+                info.description,
+                await get_bot_url_fn(deps.bot),
+            )
+
         if images:
             db_photo_url = build_tiktok_video_url_fn(info)
-            cache_key = build_media_cache_key(db_photo_url, item_index=0, item_kind="photo")
-            db_id = await deps.db.get_file_id(cache_key)
-            if not db_id:
-                if not channel_id:
-                    logging.error("CHANNEL_ID is not configured; TikTok inline upload is disabled")
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-                sent = await deps.bot.send_photo(
-                    chat_id=channel_id,
-                    photo=images[0],
-                    caption=f"TikTok Photo from {actor_name}",
-                )
-                if not sent.photo:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-                db_id = sent.photo[-1].file_id
-                await deps.db.add_file(cache_key, db_id, "photo")
-            else:
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-
-            bot_url = await get_bot_url_fn(deps.bot)
-            edited = await safe_edit_inline_media_fn(
-                deps.bot,
-                inline_message_id,
-                types.InputMediaPhoto(
-                    media=db_id,
-                    caption=bm.captions(request.user_settings["captions"], info.description, bot_url),
-                    parse_mode="HTML",
-                ),
+            await deliver_inline_photo(
+                deps=deps,
+                token=token,
+                inline_message_id=inline_message_id,
+                channel_id=channel_id,
+                service_name="TikTok",
+                cache_key=build_media_cache_key(db_photo_url, item_index=0, item_kind="photo"),
+                photo_url=images[0],
+                channel_caption=f"TikTok Photo from {actor_name}",
+                build_caption=_build_caption,
                 reply_markup=kb.return_video_info_keyboard(
                     info.views,
                     info.likes,
@@ -287,37 +242,22 @@ async def send_inline_tiktok_media(
                     request.user_settings,
                     audio_callback_data=get_tiktok_audio_callback_data_fn(info),
                 ),
+                edit_status=edit_status,
+                safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+                log=logging,
             )
-            if edited:
-                complete_inline_video_request(token)
-                return
-
-            reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
             return
 
         db_video_url = build_tiktok_video_url_fn(info)
         audio_callback_data = get_tiktok_audio_callback_data_fn(info)
-        db_id = await deps.db.get_file_id(db_video_url)
 
-        if not db_id:
-            if not channel_id:
-                logging.error("CHANNEL_ID is not configured; TikTok inline upload is disabled")
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
-
+        async def _download(on_progress):
             timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
             download_name = f"{info.id}_{timestamp}_tiktok_video.mp4"
             request_id = f"tiktok_inline:{request.owner_user_id}:{request_event_id}:{info.id}"
             size_hint = get_tiktok_size_hint_fn(data)
-
-            await _edit_inline_status(bm.downloading_video_status())
-
-            on_progress = make_status_text_progress_updater("TikTok video", _edit_inline_status)
-            on_retry_download = make_retry_status_notifier(_edit_inline_status)
-
-            metrics = await asyncio.wait_for(
+            on_retry_download = make_retry_status_notifier(edit_status)
+            return await asyncio.wait_for(
                 tiktok_service.download_video(
                     db_video_url,
                     download_name,
@@ -330,44 +270,19 @@ async def send_inline_tiktok_media(
                 ),
                 timeout=420.0,
             )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
 
-            log_download_metrics("tiktok_inline", metrics)
-            download_path = metrics.path
-            if metrics.size >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.video_too_large())
-                return
-
-            await _edit_inline_status(bm.uploading_status())
-            sent = await deps.bot.send_video(
-                chat_id=channel_id,
-                video=FSInputFile(download_path),
-                caption=f"TikTok Video from {actor_name}",
-                **(await build_video_send_kwargs(download_path)),
-            )
-            db_id = sent.video.file_id
-            await deps.db.add_file(db_video_url, db_id, "video")
-            logging.info(
-                "Inline TikTok video cached: url=%s file_id=%s",
-                summarize_url_for_log(db_video_url),
-                db_id,
-            )
-        else:
-            await _edit_inline_status(bm.uploading_status())
-
-        bot_url = await get_bot_url_fn(deps.bot)
-        edited = await safe_edit_inline_media_fn(
-            deps.bot,
-            inline_message_id,
-            types.InputMediaVideo(
-                media=db_id,
-                caption=bm.captions(request.user_settings["captions"], info.description, bot_url),
-                parse_mode="HTML",
-            ),
+        await deliver_inline_video(
+            deps=deps,
+            token=token,
+            inline_message_id=inline_message_id,
+            channel_id=channel_id,
+            max_file_size=max_file_size,
+            service_name="TikTok",
+            cache_key=db_video_url,
+            channel_caption=f"TikTok Video from {actor_name}",
+            download_fn=_download,
+            progress_label="TikTok video",
+            build_caption=_build_caption,
             reply_markup=kb.return_video_info_keyboard(
                 info.views,
                 info.likes,
@@ -378,37 +293,22 @@ async def send_inline_tiktok_media(
                 request.user_settings,
                 audio_callback_data=audio_callback_data,
             ),
+            edit_status=edit_status,
+            state=state,
+            safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+            metrics_log_key="tiktok_inline",
+            log=logging,
         )
-        if edited:
-            complete_inline_video_request(token)
-            logging.info(
-                "Served inline TikTok video: inline_message_id=%s url=%s file_id=%s",
-                inline_message_id,
-                summarize_url_for_log(db_video_url),
-                db_id,
-            )
-            return
 
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    except DownloadRateLimitError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_rate_limit_text(exc.retry_after), with_retry_button=True)
-    except DownloadQueueBusyError as exc:
-        reset_inline_video_request(token)
-        await _edit_inline_status(build_queue_busy_text(exc.position), with_retry_button=True)
-    except asyncio.TimeoutError:
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.timeout_error(), with_retry_button=True)
-    except Exception as exc:
-        logging.exception(
-            "Error sending inline TikTok video: inline_message_id=%s token=%s error=%s",
-            inline_message_id,
-            token,
-            exc,
-        )
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    finally:
-        if download_path:
-            await remove_file(download_path)
+    await run_inline_send_flow(
+        token=token,
+        inline_message_id=inline_message_id,
+        actor_user_id=actor_user_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service_name="TikTok",
+        callback_data=f"inline:tiktok:{token}",
+        plan_fn=_plan,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        log=logging,
+    )

--- a/handlers/twitter.py
+++ b/handlers/twitter.py
@@ -14,7 +14,7 @@ import keyboards as kb
 import messages as bm
 from config import OUTPUT_DIR, CHANNEL_ID, MAX_FILE_SIZE
 from handlers.deps import build_handler_dependencies
-from services.media.orchestration import handle_download_backpressure, run_media_collection_flow
+from services.media.orchestration import make_message_backpressure_handler, run_media_collection_flow
 from services.media.delivery import send_cached_media_entries
 from handlers.twitter_inline import handle_twitter_inline_query, send_inline_twitter_media
 from handlers.request_dedupe import claim_message_request
@@ -36,6 +36,7 @@ from handlers.utils import (
     maybe_delete_user_message,
     react_to_message,
     remove_file,
+    register_inline_send_handlers,
     retry_async_operation,
     safe_delete_message,
     safe_edit_text,
@@ -44,8 +45,6 @@ from handlers.utils import (
     safe_answer_inline_query,
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
-    with_callback_logging,
-    with_chosen_inline_logging,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -271,6 +270,7 @@ async def _collect_media_entries(
     user_id: Optional[int] = None,
     chat_id: Optional[int] = None,
     request_id: Optional[str] = None,
+    download_dir_name: Optional[str] = None,
 ):
     return await _collect_media_entries_impl(
         tweet_id,
@@ -282,6 +282,7 @@ async def _collect_media_entries(
         user_id=user_id,
         chat_id=chat_id,
         request_id=request_id,
+        download_dir_name=download_dir_name,
     )
 
 
@@ -292,6 +293,7 @@ async def _collect_media_files(
     user_id: Optional[int] = None,
     chat_id: Optional[int] = None,
     request_id: Optional[str] = None,
+    download_dir_name: Optional[str] = None,
 ):
     return await _collect_media_files_impl(
         tweet_id,
@@ -303,6 +305,7 @@ async def _collect_media_files(
         user_id=user_id,
         chat_id=chat_id,
         request_id=request_id,
+        download_dir_name=download_dir_name,
     )
 
 
@@ -337,7 +340,8 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
         tweet_id,
     )
 
-    tweet_dir = os.path.join(OUTPUT_DIR, str(tweet_id))
+    tweet_dir_name = f"{tweet_id}_{message.chat.id}_{message.message_id}"
+    tweet_dir = os.path.join(OUTPUT_DIR, tweet_dir_name)
     os.makedirs(tweet_dir, exist_ok=True)
     logging.debug("Tweet temp directory ready: path=%s", tweet_dir)
 
@@ -347,6 +351,7 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
     comments = tweet_media['replies']
     retweets = tweet_media['retweets']
     status_message: Optional[types.Message] = None
+    delivered = False
     try:
         if business_id is None:
             status_message = await message.answer(bm.downloading_video_status())
@@ -365,6 +370,7 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
                 user_id=message.from_user.id,
                 chat_id=message.chat.id,
                 request_id=f"twitter:{message.chat.id}:{message.message_id}:{tweet_id}",
+                download_dir_name=tweet_dir_name,
             )
             logging.info(
                 "Tweet media fetched: tweet_id=%s photos=%s videos=%s",
@@ -374,26 +380,35 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
             )
             return media_entries
 
-        async def _handle_backpressure(exc: Exception) -> None:
-            await handle_download_backpressure(
-                exc,
-                business_id=business_id,
-                on_rate_limit_reply=lambda retry_after: message.reply(build_rate_limit_text(retry_after)),
-                on_queue_busy_reply=lambda position: message.reply(build_queue_busy_text(position)),
-                on_business_error=lambda: handle_download_error(message, business_id=business_id),
+        _handle_backpressure = make_message_backpressure_handler(
+            message,
+            business_id,
+            build_rate_limit_text=build_rate_limit_text,
+            build_queue_busy_text=build_queue_busy_text,
+            handle_download_error=handle_download_error,
+        )
+
+        async def _send_entries(media_entries) -> None:
+            nonlocal delivered
+            await _send_tweet_media_entries(
+                message,
+                media_entries,
+                caption_media,
+                keyboard,
             )
+            delivered = True
+
+        async def _send_empty() -> None:
+            nonlocal delivered
+            await message.answer(caption_text, reply_markup=keyboard, parse_mode="HTML")
+            delivered = True
 
         await run_media_collection_flow(
             update_status=_edit_status,
             upload_status_text=bm.uploading_status(),
             fetch_entries=_fetch_entries,
-            send_entries=lambda media_entries: _send_tweet_media_entries(
-                message,
-                media_entries,
-                caption_media,
-                keyboard,
-            ),
-            send_empty=lambda: message.answer(caption_text, reply_markup=keyboard, parse_mode="HTML"),
+            send_entries=_send_entries,
+            send_empty=_send_empty,
             delete_status_message=lambda: safe_delete_message(status_message),
             cleanup=lambda: _cleanup_tweet_dir(tweet_dir),
             on_rate_limit=_handle_backpressure,
@@ -401,11 +416,13 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
             on_too_large=lambda _exc: message.reply(bm.video_too_large()),
         )
 
-        logging.info(
-            "Tweet media delivered: user_id=%s tweet_id=%s",
-            message.from_user.id,
-            tweet_id,
-        )
+        if delivered:
+            logging.info(
+                "Tweet media delivered: user_id=%s tweet_id=%s",
+                message.from_user.id,
+                tweet_id,
+            )
+        return delivered
     except Exception as e:
         logging.exception(
             "Error processing tweet media: tweet_id=%s user_id=%s error=%s",
@@ -415,6 +432,7 @@ async def reply_media(message, tweet_id, tweet_media, bot_url, business_id, user
         )
         await react_to_message(message, "👎", business_id=business_id)
         await message.reply(bm.something_went_wrong())
+        return False
 async def _prefetch_tweet_payloads(tweet_ids: list[str]) -> list[tuple[str, dict[str, Any] | BaseException]]:
     semaphore = asyncio.Semaphore(3)
     results: list[tuple[int, str, dict[str, Any] | BaseException]] = []
@@ -481,10 +499,11 @@ async def handle_tweet_links(message, direct_url: Optional[str] = None):
                 try:
                     if isinstance(media, BaseException):
                         raise media
-                    await reply_media(message, tweet_id, media, bot_url, business_id, user_settings)
-                    if request_lease is not None:
-                        request_lease.mark_success()
-                    await maybe_delete_user_message(message, user_settings.get("delete_message"))
+                    delivered = await reply_media(message, tweet_id, media, bot_url, business_id, user_settings)
+                    if delivered:
+                        if request_lease is not None:
+                            request_lease.mark_success()
+                        await maybe_delete_user_message(message, user_settings.get("delete_message"))
                 except Exception as e:
                     logging.exception("Failed to process tweet: tweet_id=%s error=%s", tweet_id, e)
                     await message.reply(bm.something_went_wrong())
@@ -552,49 +571,17 @@ async def _send_inline_twitter_media(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("twitter_inline:"))
-@with_chosen_inline_logging("twitter", "chosen_inline")
-async def chosen_inline_twitter_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning("Chosen inline Twitter result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("twitter_inline:")
-    await _send_inline_twitter_media(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_twitter_result, send_inline_twitter_media_callback = (
+    register_inline_send_handlers(
+        router,
+        service="twitter",
+        result_prefix="twitter_inline:",
+        callback_prefix="inline:twitter:",
+        send_fn=_send_inline_twitter_media,
+        missing_inline_message_warning=(
+            "Chosen inline Twitter result is missing inline_message_id"
+        ),
+        chosen_handler_name="chosen_inline_twitter_result",
+        callback_handler_name="send_inline_twitter_media_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:twitter:"))
-@with_callback_logging("twitter", "inline_callback")
-async def send_inline_twitter_media_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:twitter:")
-    await call.answer()
-    try:
-        await _send_inline_twitter_media(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
+)

--- a/handlers/twitter_inline.py
+++ b/handlers/twitter_inline.py
@@ -3,33 +3,31 @@ from typing import Optional
 from urllib.parse import urlsplit
 
 from aiogram import types
-from aiogram.types import FSInputFile
 
 import keyboards as kb
 import messages as bm
 from handlers.deps import HandlerDependencies
 from handlers.utils import (
     build_inline_album_result,
-    build_inline_status_editor,
     build_start_deeplink_url,
     get_bot_url,
-    make_status_text_progress_updater,
-    remove_file,
     safe_answer_inline_query,
     safe_edit_inline_media,
     safe_edit_inline_text,
 )
-from services.logger import logger as logging, summarize_text_for_log, summarize_url_for_log
+from services.logger import logger as logging, summarize_text_for_log
 from services.inline.album_links import create_inline_album_request
+from services.inline.send_flow import (
+    deliver_inline_photo,
+    deliver_inline_video,
+    ensure_album_preview_file_id,
+    run_inline_send_flow,
+)
 from services.inline.service_icons import get_inline_service_icon
 from services.inline.video_requests import (
-    claim_inline_video_request_for_send,
     complete_inline_video_request,
     create_inline_video_request,
-    reset_inline_video_request,
 )
-from services.media.video_metadata import build_video_send_kwargs
-from utils.download_manager import log_download_metrics
 
 logging = logging.bind(service="twitter_inline")
 
@@ -65,8 +63,10 @@ async def handle_twitter_inline_query(
         source_url = match.group(0)
         user_settings = await deps.db.user_settings(query.from_user.id)
         bot_url = await get_bot_url_fn(deps.bot)
-        album_token = create_inline_album_request(query.from_user.id, "twitter", source_url)
-        album_deep_link = build_start_deeplink_url(bot_url, f"album_{album_token}")
+        def _album_deep_link() -> str:
+            album_token = create_inline_album_request(query.from_user.id, "twitter", source_url)
+            return build_start_deeplink_url(bot_url, f"album_{album_token}")
+
         context = await get_tweet_context_fn(source_url)
         if not context:
             await safe_answer_inline_query_fn(
@@ -74,7 +74,7 @@ async def handle_twitter_inline_query(
                 [
                     build_twitter_open_in_bot_result_fn(
                         result_id="twitter_open_in_bot",
-                        deep_link=album_deep_link,
+                        deep_link=_album_deep_link(),
                         description="Open this post in the bot.",
                     )
                 ],
@@ -89,25 +89,16 @@ async def handle_twitter_inline_query(
             preview_file_id = None
             first_media = media_items[0]
             first_media_kind = normalize_twitter_media_kind_fn(first_media.get("type"))
-            if first_media_kind == "photo" and channel_id:
-                preview_cache_key = build_twitter_media_cache_key_fn(source_url, 0, "photo", len(media_items))
-                preview_file_id = await deps.db.get_file_id(preview_cache_key)
-                if not preview_file_id:
-                    try:
-                        sent = await deps.bot.send_photo(
-                            chat_id=channel_id,
-                            photo=first_media["url"],
-                            caption="X / Twitter Album Preview",
-                        )
-                        if sent.photo:
-                            preview_file_id = sent.photo[-1].file_id
-                            await deps.db.add_file(preview_cache_key, preview_file_id, "photo")
-                    except Exception as exc:
-                        logging.warning(
-                            "Failed to cache Twitter album preview photo: url=%s error=%s",
-                            summarize_url_for_log(source_url),
-                            exc,
-                        )
+            if first_media_kind == "photo":
+                preview_file_id = await ensure_album_preview_file_id(
+                    deps=deps,
+                    channel_id=channel_id,
+                    photo_url=first_media["url"],
+                    cache_key=build_twitter_media_cache_key_fn(source_url, 0, "photo", len(media_items)),
+                    service_name="X / Twitter",
+                    source_url=source_url,
+                    log=logging,
+                )
             preview_url = get_twitter_media_preview_url_fn(media_items[0], tweet_media) or next(
                 (
                     get_twitter_media_preview_url_fn(item, tweet_media)
@@ -120,7 +111,7 @@ async def handle_twitter_inline_query(
                 build_inline_album_result(
                     result_id=f"twitter_album_{tweet_id}",
                     service_name="Twitter",
-                    deep_link=album_deep_link,
+                    deep_link=_album_deep_link(),
                     message_text=bm.captions(
                         user_settings["captions"],
                         tweet_media.get("text"),
@@ -140,7 +131,7 @@ async def handle_twitter_inline_query(
                 [
                     build_twitter_open_in_bot_result_fn(
                         result_id=f"twitter_open_{tweet_id}",
-                        deep_link=album_deep_link,
+                        deep_link=_album_deep_link(),
                         description="Inline preview is limited for this post. Open it in the bot.",
                     )
                 ],
@@ -157,7 +148,7 @@ async def handle_twitter_inline_query(
                 [
                     build_twitter_open_in_bot_result_fn(
                         result_id=f"twitter_open_unknown_{tweet_id}",
-                        deep_link=album_deep_link,
+                        deep_link=_album_deep_link(),
                         description="Open this post in the bot.",
                     )
                 ],
@@ -214,42 +205,25 @@ async def send_inline_twitter_media(
     safe_edit_inline_media_fn=safe_edit_inline_media,
     safe_edit_inline_text_fn=safe_edit_inline_text,
 ) -> None:
-    request = claim_inline_video_request_for_send(
-        token,
-        duplicate_handler=duplicate_handler,
-        actor_user_id=actor_user_id,
-    )
-    if request is None:
-        return
-
-    download_path: Optional[str] = None
-
-    _edit_inline_status = build_inline_status_editor(
-        bot=deps.bot,
-        inline_message_id=inline_message_id,
-        callback_data_factory=lambda _media_kind: f"inline:twitter:{token}",
-        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
-    )
-
-    try:
+    async def _plan(request, edit_status, state) -> None:
         context = await get_tweet_context_fn(request.source_url)
         if not context:
             complete_inline_video_request(token)
-            await _edit_inline_status("Only single photo or single video posts are supported inline.")
+            await edit_status("Only single photo or single video posts are supported inline.")
             return
 
         _, tweet_media = context
         media_items = extract_twitter_media_items_fn(tweet_media)
         if len(media_items) != 1:
             complete_inline_video_request(token)
-            await _edit_inline_status("Only single photo or single video posts are supported inline.")
+            await edit_status("Only single photo or single video posts are supported inline.")
             return
 
         media = media_items[0]
         media_kind = normalize_twitter_media_kind_fn(media.get("type"))
         if not media_kind:
             complete_inline_video_request(token)
-            await _edit_inline_status("Only single photo or single video posts are supported inline.")
+            await edit_status("Only single photo or single video posts are supported inline.")
             return
         post_url = tweet_media["tweetURL"]
         post_caption = tweet_media.get("text")
@@ -257,69 +231,47 @@ async def send_inline_twitter_media(
         comments = tweet_media.get("replies")
         retweets = tweet_media.get("retweets")
 
-        if media_kind == "photo":
-            cache_key = build_twitter_media_cache_key_fn(post_url, 0, "photo", 1)
-            db_file_id = await deps.db.get_file_id(cache_key)
-            if not db_file_id:
-                if not channel_id:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-                sent = await deps.bot.send_photo(
-                    chat_id=channel_id,
-                    photo=media["url"],
-                    caption=f"X / Twitter Photo from {actor_name}",
-                )
-                if not sent.photo:
-                    reset_inline_video_request(token)
-                    await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
-                    return
-                db_file_id = sent.photo[-1].file_id
-                await deps.db.add_file(cache_key, db_file_id, "photo")
-            else:
-                await _edit_inline_status(bm.uploading_status(), media_kind="photo")
-
-            edited = await safe_edit_inline_media_fn(
-                deps.bot,
-                inline_message_id,
-                types.InputMediaPhoto(
-                    media=db_file_id,
-                    caption=bm.captions(request.user_settings["captions"], post_caption, await get_bot_url_fn(deps.bot)),
-                    parse_mode="HTML",
-                ),
-                reply_markup=kb.return_video_info_keyboard(
-                    None,
-                    likes,
-                    comments,
-                    retweets,
-                    None,
-                    post_url,
-                    request.user_settings,
-                ),
+        async def _build_caption():
+            return bm.captions(
+                request.user_settings["captions"],
+                post_caption,
+                await get_bot_url_fn(deps.bot),
             )
-            if edited:
-                complete_inline_video_request(token)
-                return
-            reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
+
+        reply_markup = kb.return_video_info_keyboard(
+            None,
+            likes,
+            comments,
+            retweets,
+            None,
+            post_url,
+            request.user_settings,
+        )
+
+        if media_kind == "photo":
+            await deliver_inline_photo(
+                deps=deps,
+                token=token,
+                inline_message_id=inline_message_id,
+                channel_id=channel_id,
+                service_name="X / Twitter",
+                cache_key=build_twitter_media_cache_key_fn(post_url, 0, "photo", 1),
+                photo_url=media["url"],
+                channel_caption=f"X / Twitter Photo from {actor_name}",
+                build_caption=_build_caption,
+                reply_markup=reply_markup,
+                edit_status=edit_status,
+                safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+                log=logging,
+            )
             return
 
-        cache_key = post_url
-        db_file_id = await deps.db.get_file_id(cache_key)
-        if not db_file_id:
-            if not channel_id:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
-
-            file_name = os.path.join(str(tweet_media["conversationID"]), os.path.basename(urlsplit(media["url"]).path))
-            await _edit_inline_status(bm.downloading_video_status())
-
-            on_progress = make_status_text_progress_updater("X / Twitter video", _edit_inline_status)
-
-            metrics = await twitter_downloader.download(
+        async def _download(on_progress):
+            file_name = os.path.join(
+                f"{tweet_media['conversationID']}_inline_{token}",
+                os.path.basename(urlsplit(media["url"]).path),
+            )
+            return await twitter_downloader.download(
                 media["url"],
                 file_name,
                 skip_if_exists=True,
@@ -328,63 +280,36 @@ async def send_inline_twitter_media(
                 max_size_bytes=max_file_size,
                 on_progress=on_progress,
             )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
 
-            log_download_metrics("twitter_inline", metrics)
-            download_path = metrics.path
-            if metrics.size >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.video_too_large())
-                return
-
-            await _edit_inline_status(bm.uploading_status())
-            sent = await deps.bot.send_video(
-                chat_id=channel_id,
-                video=FSInputFile(download_path),
-                caption=f"X / Twitter Video from {actor_name}",
-                **(await build_video_send_kwargs(download_path)),
-            )
-            db_file_id = sent.video.file_id
-            await deps.db.add_file(cache_key, db_file_id, "video")
-        else:
-            await _edit_inline_status(bm.uploading_status())
-
-        edited = await safe_edit_inline_media_fn(
-            deps.bot,
-            inline_message_id,
-            types.InputMediaVideo(
-                media=db_file_id,
-                caption=bm.captions(request.user_settings["captions"], post_caption, await get_bot_url_fn(deps.bot)),
-                parse_mode="HTML",
-            ),
-            reply_markup=kb.return_video_info_keyboard(
-                None,
-                likes,
-                comments,
-                retweets,
-                None,
-                post_url,
-                request.user_settings,
-            ),
+        await deliver_inline_video(
+            deps=deps,
+            token=token,
+            inline_message_id=inline_message_id,
+            channel_id=channel_id,
+            max_file_size=max_file_size,
+            service_name="X / Twitter",
+            cache_key=post_url,
+            channel_caption=f"X / Twitter Video from {actor_name}",
+            download_fn=_download,
+            progress_label="X / Twitter video",
+            build_caption=_build_caption,
+            reply_markup=reply_markup,
+            edit_status=edit_status,
+            state=state,
+            safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+            metrics_log_key="twitter_inline",
+            log=logging,
         )
-        if edited:
-            complete_inline_video_request(token)
-            return
 
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    except Exception as exc:
-        logging.exception(
-            "Error sending Twitter inline media: inline_message_id=%s token=%s error=%s",
-            inline_message_id,
-            token,
-            exc,
-        )
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    finally:
-        if download_path:
-            await remove_file(download_path)
+    await run_inline_send_flow(
+        token=token,
+        inline_message_id=inline_message_id,
+        actor_user_id=actor_user_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service_name="X / Twitter",
+        callback_data=f"inline:twitter:{token}",
+        plan_fn=_plan,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        log=logging,
+    )

--- a/handlers/user.py
+++ b/handlers/user.py
@@ -12,8 +12,6 @@ from services.download.queue import get_download_queue  # noqa: F401
 from services.runtime.pending_requests import pop_pending  # noqa: F401
 from services.stats.chart import _render_stats  # noqa: F401
 
-from config import BATCH_LINKS_MAX_ITEMS
-
 from handlers import commands as cmd_mod
 from handlers import media_download as media_mod
 from handlers import settings_menu as settings_mod
@@ -22,7 +20,7 @@ router = Router(name=__name__)
 
 _UPDATE_INFO_TTL_SECONDS = cmd_mod._UPDATE_INFO_TTL_SECONDS
 _update_info_cache = cmd_mod._update_info_cache
-_MAX_BATCH_LINKS = max(1, int(BATCH_LINKS_MAX_ITEMS))
+_MAX_BATCH_LINKS = media_mod._MAX_BATCH_LINKS
 _MESSAGE_NOT_MODIFIED_MARKERS = (
     "message is not modified",
     "specified new message content and reply markup are exactly the same",

--- a/handlers/utils.py
+++ b/handlers/utils.py
@@ -16,6 +16,8 @@ from handlers.inline_utils import (
     build_inline_album_result,
     build_inline_status_editor,
     build_start_deeplink_url,
+    register_inline_send_handlers,
+    run_inline_send_callback,
     safe_answer_inline_query,
     sanitize_inline_results,
 )
@@ -57,6 +59,21 @@ from handlers.telegram_ui_utils import (
     send_chat_action_if_needed,
 )
 
+def make_backpressure_handler(message, business_id):
+    """Build the shared backpressure closure used by the single-media flows:
+    forwards DownloadRateLimitError/DownloadQueueBusyError to the user-facing
+    handler, showing service status only outside business chats."""
+
+    async def _handle_backpressure(exc: Exception) -> None:
+        await handle_download_backpressure_error(
+            exc,
+            message=message,
+            show_service_status=business_id is None,
+        )
+
+    return _handle_backpressure
+
+
 __all__ = [
     "_bot_avatar_file_id",
     "_bot_avatar_path",
@@ -88,13 +105,16 @@ __all__ = [
     "load_user_settings",
     "log_context_scope",
     "log_duration",
+    "make_backpressure_handler",
     "make_retry_status_notifier",
     "make_status_text_progress_updater",
     "maybe_delete_user_message",
     "react_to_message",
+    "register_inline_send_handlers",
     "remove_file",
     "resolve_settings_target_id",
     "retry_async_operation",
+    "run_inline_send_callback",
     "safe_answer_inline_query",
     "safe_delete_message",
     "safe_edit_inline_media",

--- a/handlers/youtube.py
+++ b/handlers/youtube.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 
 from aiogram import types, Router, F
 from aiogram.types import FSInputFile
-from aiogram.exceptions import TelegramBadRequest
 from yt_dlp import YoutubeDL
 
 import keyboards as kb
@@ -18,10 +17,14 @@ from handlers.youtube_inline import (
     send_inline_youtube_music,
     send_inline_youtube_video,
 )
+from services.media.audio_flow import run_audio_flow
 from services.media.orchestration import run_single_media_flow
 from services.media.audio_metadata import build_audio_filename, prepare_mp3_metadata
-from services.media.delivery import AUDIO_CACHE_VARIANT, send_audio_with_thumbnail
-from services.media.video_metadata import build_video_send_kwargs
+from services.media.delivery import (
+    AUDIO_CACHE_VARIANT,
+    make_video_or_document_senders,
+    send_audio_with_thumbnail,
+)
 from handlers.user import update_info
 from handlers.utils import (
     get_bot_url,
@@ -31,6 +34,7 @@ from handlers.utils import (
     handle_download_error,
     handle_video_too_large,
     load_user_settings,
+    make_backpressure_handler,
     make_retry_status_notifier,
     make_status_text_progress_updater,
     maybe_delete_user_message,
@@ -44,8 +48,7 @@ from handlers.utils import (
     send_chat_action_if_needed,
     should_skip_duplicate_business_message,
     retry_async_operation,
-    with_callback_logging,
-    with_chosen_inline_logging,
+    register_inline_send_handlers,
     with_inline_query_logging,
     with_inline_send_logging,
     with_message_logging,
@@ -209,38 +212,27 @@ async def _download_youtube_media(
     on_progress: Any,
     on_retry_download: Any,
 ) -> DownloadMetrics | None:
+    async def _ytdlp_fallback(source: str) -> DownloadMetrics | None:
+        return await asyncio.wait_for(
+            retry_async_operation(
+                lambda: download_with_ytdlp_metrics(
+                    yt["webpage_url"],
+                    name,
+                    YTDLP_FORMAT_720,
+                    source,
+                    max_filesize=MAX_FILE_SIZE - 1,
+                ),
+                attempts=3,
+                should_retry_result=lambda result: result is None,
+                on_retry=on_retry_download,
+            ),
+            timeout=900.0,
+        )
+
     if not video:
-        return await asyncio.wait_for(
-            retry_async_operation(
-                lambda: download_with_ytdlp_metrics(
-                    yt["webpage_url"],
-                    name,
-                    YTDLP_FORMAT_720,
-                    "youtube_video_ytdlp_merged",
-                    max_filesize=MAX_FILE_SIZE - 1,
-                ),
-                attempts=3,
-                should_retry_result=lambda result: result is None,
-                on_retry=on_retry_download,
-            ),
-            timeout=900.0,
-        )
+        return await _ytdlp_fallback("youtube_video_ytdlp_merged")
     if _is_manifest_stream(video):
-        return await asyncio.wait_for(
-            retry_async_operation(
-                lambda: download_with_ytdlp_metrics(
-                    yt["webpage_url"],
-                    name,
-                    YTDLP_FORMAT_720,
-                    "youtube_video_ytdlp_manifest",
-                    max_filesize=MAX_FILE_SIZE - 1,
-                ),
-                attempts=3,
-                should_retry_result=lambda result: result is None,
-                on_retry=on_retry_download,
-            ),
-            timeout=900.0,
-        )
+        return await _ytdlp_fallback("youtube_video_ytdlp_manifest")
 
     metrics = await asyncio.wait_for(
         download_stream(
@@ -258,21 +250,7 @@ async def _download_youtube_media(
     )
     if metrics:
         return metrics
-    return await asyncio.wait_for(
-        retry_async_operation(
-            lambda: download_with_ytdlp_metrics(
-                yt["webpage_url"],
-                name,
-                YTDLP_FORMAT_720,
-                "youtube_video_ytdlp_merged",
-                max_filesize=MAX_FILE_SIZE - 1,
-            ),
-            attempts=3,
-            should_retry_result=lambda result: result is None,
-            on_retry=on_retry_download,
-        ),
-        timeout=900.0,
-    )
+    return await _ytdlp_fallback("youtube_video_ytdlp_merged")
 
 
 @router.message(
@@ -378,46 +356,16 @@ async def download_video(message: types.Message, direct_url: Optional[str] = Non
 
         as_document = user_settings.get("as_document") == "on"
 
-        async def _send_cached(file_id: str):
-            logging.info(
-                "Serving cached YouTube video: url=%s file_id=%s",
-                summarize_url_for_log(yt["webpage_url"]),
-                file_id,
-            )
-            try:
-                if as_document:
-                    return await message.reply_document(
-                        document=file_id,
-                        caption=bm.captions(user_captions, yt["title"], bot_url),
-                        reply_markup=_reply_markup(),
-                        parse_mode="HTML",
-                        disable_content_type_detection=True,
-                    )
-                return await message.reply_video(
-                    video=file_id,
-                    caption=bm.captions(user_captions, yt["title"], bot_url),
-                    reply_markup=_reply_markup(),
-                    parse_mode="HTML",
-                )
-            except TelegramBadRequest:
-                return None
-
-        async def _send_downloaded(path: str):
-            if as_document:
-                return await message.reply_document(
-                    document=FSInputFile(path),
-                    caption=bm.captions(user_captions, yt["title"], bot_url),
-                    reply_markup=_reply_markup(),
-                    parse_mode="HTML",
-                    disable_content_type_detection=True,
-                )
-            return await message.reply_video(
-                video=FSInputFile(path),
+        _send_cached, _send_downloaded, _extract_file_id = (
+            make_video_or_document_senders(
+                message,
                 caption=bm.captions(user_captions, yt["title"], bot_url),
-                reply_markup=_reply_markup(),
-                parse_mode="HTML",
-                **(await build_video_send_kwargs(path)),
+                reply_markup_fn=_reply_markup,
+                as_document=as_document,
+                cached_log_label="YouTube video",
+                cached_log_url=yt["webpage_url"],
             )
+        )
 
         async def _after_send():
             await maybe_delete_user_message(
@@ -430,12 +378,7 @@ async def download_video(message: types.Message, direct_url: Optional[str] = Non
                 return False
             return True
 
-        async def _handle_backpressure(exc: Exception) -> None:
-            await handle_download_backpressure_error(
-                exc,
-                message=message,
-                show_service_status=business_id is None,
-            )
+        _handle_backpressure = make_backpressure_handler(message, business_id)
 
         cache_key = f"{yt['webpage_url']}#document" if as_document else yt["webpage_url"]
         cache_file_type = "document" if as_document else "video"
@@ -453,9 +396,7 @@ async def download_video(message: types.Message, direct_url: Optional[str] = Non
             send_cached=_send_cached,
             download_media=_download_media,
             send_downloaded=_send_downloaded,
-            extract_file_id=lambda sent: (
-                sent.document.file_id if getattr(sent, "document", None) else (sent.video.file_id if getattr(sent, "video", None) else None)
-            ),
+            extract_file_id=_extract_file_id,
             cleanup_path=remove_file,
             delete_status_message=lambda: safe_delete_message(status_message),
             on_missing_media=lambda: handle_download_error(
@@ -546,28 +487,6 @@ async def download_music(message: types.Message, direct_url: Optional[str] = Non
         cache_key = build_media_cache_key(
             yt["webpage_url"], variant=AUDIO_CACHE_VARIANT
         )
-        db_file_id = await db.get_file_id(cache_key)
-        if db_file_id:
-            await safe_edit_text(status_message, bm.uploading_status())
-            await send_chat_action_if_needed(
-                bot, message.chat.id, "upload_audio", business_id
-            )
-            await send_audio_with_thumbnail(
-                message.reply_audio,
-                audio=db_file_id,
-                title=yt["title"],
-                performer=audio_artist,
-                caption=bm.captions(user_settings.get("captions"), None, bot_url),
-                bot_url=bot_url,
-                duration=audio_duration,
-                parse_mode="HTML",
-            )
-            await maybe_delete_user_message(
-                message, user_settings.get("delete_message")
-            )
-            request_lease.mark_success()
-            return
-
         base_name = f"{yt['id']}_youtube_audio"
 
         async def on_retry_download(failed_attempt: int, total_attempts: int, _error):
@@ -577,38 +496,49 @@ async def download_music(message: types.Message, direct_url: Optional[str] = Non
                     bm.retrying_again_status(failed_attempt + 1, total_attempts),
                 )
 
-        metrics = await retry_async_operation(
-            lambda: download_mp3_with_ytdlp_metrics(
-                yt["webpage_url"],
-                base_name,
-                "youtube_audio_mp3",
-                max_filesize=MAX_FILE_SIZE - 1,
-            ),
-            attempts=3,
-            delay_seconds=2.0,
-            should_retry_result=lambda result: result is None,
-            on_retry=on_retry_download,
-        )
-        if not metrics:
-            await handle_download_error(message, business_id=business_id)
-            return
-        if metrics.size >= MAX_FILE_SIZE:
-            await message.reply(bm.audio_too_large())
-            await remove_file(metrics.path)
-            return
+        async def _send_cached(file_id: str):
+            await safe_edit_text(status_message, bm.uploading_status())
+            await send_chat_action_if_needed(
+                bot, message.chat.id, "upload_audio", business_id
+            )
+            return await send_audio_with_thumbnail(
+                message.reply_audio,
+                audio=file_id,
+                title=yt["title"],
+                performer=audio_artist,
+                caption=bm.captions(user_settings.get("captions"), None, bot_url),
+                bot_url=bot_url,
+                duration=audio_duration,
+                parse_mode="HTML",
+            )
 
-        prepared_metadata = await prepare_mp3_metadata(
-            metrics.path,
-            {
-                **yt,
-                "artists": audio_artist,
-                "thumbnail": thumbnail_url,
-                "source_url": url,
-                "date": yt.get("release_date") or yt.get("upload_date"),
-            },
-        )
+        async def _download_audio():
+            return await retry_async_operation(
+                lambda: download_mp3_with_ytdlp_metrics(
+                    yt["webpage_url"],
+                    base_name,
+                    "youtube_audio_mp3",
+                    max_filesize=MAX_FILE_SIZE - 1,
+                ),
+                attempts=3,
+                delay_seconds=2.0,
+                should_retry_result=lambda result: result is None,
+                on_retry=on_retry_download,
+            )
 
-        try:
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(
+                path,
+                {
+                    **yt,
+                    "artists": audio_artist,
+                    "thumbnail": thumbnail_url,
+                    "source_url": url,
+                    "date": yt.get("release_date") or yt.get("upload_date"),
+                },
+            )
+
+        async def _send_downloaded(path: str, prepared_metadata):
             await safe_edit_text(status_message, bm.uploading_status())
             await send_chat_action_if_needed(
                 bot, message.chat.id, "upload_voice", business_id
@@ -618,29 +548,50 @@ async def download_music(message: types.Message, direct_url: Optional[str] = Non
                 if prepared_metadata.thumbnail_path
                 else bot_avatar
             )
-            sent_message = await send_audio_with_thumbnail(
+            return await send_audio_with_thumbnail(
                 message.reply_audio,
                 audio=FSInputFile(
-                    metrics.path,
+                    path,
                     filename=build_audio_filename(yt.get("title")),
                 ),
                 title=yt["title"],
                 performer=audio_artist,
                 caption=bm.captions(user_settings.get("captions"), None, bot_url),
-                audio_path=metrics.path,
+                audio_path=path,
                 bot_avatar=audio_thumbnail,
                 bot_url=bot_url,
                 duration=audio_duration,
                 embed_thumbnail=False,
                 parse_mode="HTML",
             )
-            await maybe_delete_user_message(message, user_settings.get("delete_message"))
-            await db.add_file(cache_key, sent_message.audio.file_id, "audio")
-            request_lease.mark_success()
-        finally:
-            prepared_metadata.cleanup()
 
-        await remove_file(metrics.path)
+        async def _after_send(_result):
+            await maybe_delete_user_message(
+                message, user_settings.get("delete_message")
+            )
+            request_lease.mark_success()
+
+        async def _on_missing_audio():
+            await handle_download_error(message, business_id=business_id)
+
+        async def _on_too_large():
+            await message.reply(bm.audio_too_large())
+
+        result = await run_audio_flow(
+            cache_key=cache_key,
+            db_service=db,
+            send_cached=_send_cached,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=MAX_FILE_SIZE,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+            on_after_send=_after_send,
+        )
+        if not result or result.from_cache:
+            return
     except (DownloadRateLimitError, DownloadQueueBusyError, DownloadTooLargeError) as e:
         await handle_download_backpressure_error(
             e,
@@ -701,24 +652,6 @@ async def download_youtube_mp3_callback(call: types.CallbackQuery):
         cache_key = build_media_cache_key(
             yt["webpage_url"], variant=AUDIO_CACHE_VARIANT
         )
-        db_file_id = await db.get_file_id(cache_key)
-        if db_file_id:
-            await safe_edit_text(status_message, bm.uploading_status())
-            await send_chat_action_if_needed(
-                bot, call.message.chat.id, "upload_audio", business_id
-            )
-            await send_audio_with_thumbnail(
-                call.message.reply_audio,
-                audio=db_file_id,
-                title=yt.get("title"),
-                performer=audio_artist,
-                caption=bm.captions(None, None, bot_url),
-                bot_url=bot_url,
-                duration=audio_duration,
-                parse_mode="HTML",
-            )
-            return
-
         base_name = f"{yt['id']}_youtube_audio"
 
         async def on_retry_download(failed_attempt: int, total_attempts: int, _error):
@@ -728,39 +661,49 @@ async def download_youtube_mp3_callback(call: types.CallbackQuery):
                     bm.retrying_again_status(failed_attempt + 1, total_attempts),
                 )
 
-        metrics = await retry_async_operation(
-            lambda: download_mp3_with_ytdlp_metrics(
-                yt["webpage_url"],
-                base_name,
-                "youtube_audio_mp3",
-                max_filesize=MAX_FILE_SIZE - 1,
-            ),
-            attempts=3,
-            delay_seconds=2.0,
-            should_retry_result=lambda result: result is None,
-            on_retry=on_retry_download,
-        )
-        if not metrics:
-            await handle_download_error(call.message, business_id=business_id)
-            return
+        async def _send_cached(file_id: str):
+            await safe_edit_text(status_message, bm.uploading_status())
+            await send_chat_action_if_needed(
+                bot, call.message.chat.id, "upload_audio", business_id
+            )
+            return await send_audio_with_thumbnail(
+                call.message.reply_audio,
+                audio=file_id,
+                title=yt.get("title"),
+                performer=audio_artist,
+                caption=bm.captions(None, None, bot_url),
+                bot_url=bot_url,
+                duration=audio_duration,
+                parse_mode="HTML",
+            )
 
-        if metrics.size >= MAX_FILE_SIZE:
-            await call.message.reply(bm.audio_too_large())
-            await remove_file(metrics.path)
-            return
+        async def _download_audio():
+            return await retry_async_operation(
+                lambda: download_mp3_with_ytdlp_metrics(
+                    yt["webpage_url"],
+                    base_name,
+                    "youtube_audio_mp3",
+                    max_filesize=MAX_FILE_SIZE - 1,
+                ),
+                attempts=3,
+                delay_seconds=2.0,
+                should_retry_result=lambda result: result is None,
+                on_retry=on_retry_download,
+            )
 
-        prepared_metadata = await prepare_mp3_metadata(
-            metrics.path,
-            {
-                **yt,
-                "artists": audio_artist,
-                "thumbnail": thumbnail_url,
-                "source_url": url,
-                "date": yt.get("release_date") or yt.get("upload_date"),
-            },
-        )
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(
+                path,
+                {
+                    **yt,
+                    "artists": audio_artist,
+                    "thumbnail": thumbnail_url,
+                    "source_url": url,
+                    "date": yt.get("release_date") or yt.get("upload_date"),
+                },
+            )
 
-        try:
+        async def _send_downloaded(path: str, prepared_metadata):
             await send_chat_action_if_needed(
                 bot, call.message.chat.id, "upload_audio", business_id
             )
@@ -770,33 +713,61 @@ async def download_youtube_mp3_callback(call: types.CallbackQuery):
                 if prepared_metadata.thumbnail_path
                 else bot_avatar
             )
-            sent_message = await send_audio_with_thumbnail(
+            return await send_audio_with_thumbnail(
                 call.message.reply_audio,
                 audio=FSInputFile(
-                    metrics.path,
+                    path,
                     filename=build_audio_filename(yt.get("title")),
                 ),
                 title=yt.get("title"),
                 performer=audio_artist,
                 caption=bm.captions(None, None, bot_url),
-                audio_path=metrics.path,
+                audio_path=path,
                 bot_avatar=audio_thumbnail,
                 bot_url=bot_url,
                 duration=audio_duration,
                 embed_thumbnail=False,
                 parse_mode="HTML",
             )
-            await db.add_file(cache_key, sent_message.audio.file_id, "audio")
-        finally:
-            prepared_metadata.cleanup()
 
-        await remove_file(metrics.path)
+        async def _on_missing_audio():
+            await handle_download_error(call.message, business_id=business_id)
+
+        async def _on_too_large():
+            await call.message.reply(bm.audio_too_large())
+
+        await run_audio_flow(
+            cache_key=cache_key,
+            db_service=db,
+            send_cached=_send_cached,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=MAX_FILE_SIZE,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+        )
+    except (DownloadRateLimitError, DownloadQueueBusyError, DownloadTooLargeError) as e:
+        await handle_download_backpressure_error(
+            e,
+            message=call.message,
+            show_service_status=show_service_status,
+            too_large_text=bm.audio_too_large(),
+        )
     except asyncio.TimeoutError:
         if show_service_status:
             await safe_edit_text(status_message, bm.timeout_error())
         await handle_download_error(
             call.message, business_id=business_id, text=bm.timeout_error()
         )
+    except Exception as e:
+        logging.exception(
+            "Error downloading YouTube MP3: url=%s error=%s",
+            summarize_url_for_log(url),
+            e,
+        )
+        await handle_download_error(call.message, business_id=business_id)
     finally:
         await safe_delete_message(status_message)
 
@@ -898,99 +869,37 @@ async def _send_inline_youtube_video(
     )
 
 
-@router.chosen_inline_result(F.result_id.startswith("ytmusic_inline:"))
-@with_chosen_inline_logging("youtube", "music_chosen_inline")
-async def chosen_inline_youtube_music_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning(
+chosen_inline_youtube_music_result, send_inline_youtube_music_callback = (
+    register_inline_send_handlers(
+        router,
+        service="youtube",
+        result_prefix="ytmusic_inline:",
+        callback_prefix="inline:ytmusic:",
+        send_fn=_send_inline_youtube_music,
+        missing_inline_message_warning=(
             "Chosen inline YouTube Music result is missing inline_message_id"
-        )
-        return
-
-    token = result.result_id.removeprefix("ytmusic_inline:")
-    await _send_inline_youtube_music(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+        ),
+        chosen_flow="music_chosen_inline",
+        callback_flow="music_inline_callback",
+        chosen_handler_name="chosen_inline_youtube_music_result",
+        callback_handler_name="send_inline_youtube_music_callback",
     )
+)
 
 
-@router.callback_query(F.data.startswith("inline:ytmusic:"))
-@with_callback_logging("youtube", "music_inline_callback")
-async def send_inline_youtube_music_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:ytmusic:")
-    await call.answer()
-    try:
-        await _send_inline_youtube_music(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
-
-
-@router.chosen_inline_result(F.result_id.startswith("youtube_inline:"))
-@with_chosen_inline_logging("youtube", "video_chosen_inline")
-async def chosen_inline_youtube_result(result: types.ChosenInlineResult):
-    if not result.inline_message_id:
-        logging.warning("Chosen inline YouTube result is missing inline_message_id")
-        return
-
-    token = result.result_id.removeprefix("youtube_inline:")
-    await _send_inline_youtube_video(
-        token=token,
-        inline_message_id=result.inline_message_id,
-        actor_name=result.from_user.full_name,
-        actor_user_id=getattr(result.from_user, "id", None),
-        request_event_id=result.result_id,
-        duplicate_handler="chosen",
+chosen_inline_youtube_result, send_inline_youtube_video_callback = (
+    register_inline_send_handlers(
+        router,
+        service="youtube",
+        result_prefix="youtube_inline:",
+        callback_prefix="inline:youtube:",
+        send_fn=_send_inline_youtube_video,
+        missing_inline_message_warning=(
+            "Chosen inline YouTube result is missing inline_message_id"
+        ),
+        chosen_flow="video_chosen_inline",
+        callback_flow="video_inline_callback",
+        chosen_handler_name="chosen_inline_youtube_result",
+        callback_handler_name="send_inline_youtube_video_callback",
     )
-
-
-@router.callback_query(F.data.startswith("inline:youtube:"))
-@with_callback_logging("youtube", "video_inline_callback")
-async def send_inline_youtube_video_callback(call: types.CallbackQuery):
-    if not call.inline_message_id:
-        await call.answer("This button works only in inline mode.", show_alert=True)
-        return
-
-    token = call.data.removeprefix("inline:youtube:")
-    await call.answer()
-    try:
-        await _send_inline_youtube_video(
-            token=token,
-            inline_message_id=call.inline_message_id,
-            actor_name=call.from_user.full_name,
-            actor_user_id=call.from_user.id,
-            request_event_id=str(call.id),
-            duplicate_handler="callback",
-        )
-    except PermissionError:
-        await call.answer(bm.something_went_wrong(), show_alert=True)
-        return
-    except ValueError as exc:
-        if str(exc) == "already_processing":
-            await call.answer(bm.inline_video_already_processing(), show_alert=False)
-            return
-        if str(exc) == "already_completed":
-            await call.answer(bm.inline_video_already_sent(), show_alert=False)
-            return
+)

--- a/handlers/youtube_inline.py
+++ b/handlers/youtube_inline.py
@@ -9,14 +9,20 @@ import messages as bm
 from handlers.deps import HandlerDependencies
 from handlers.utils import (
     build_inline_status_editor,
+    build_queue_busy_text,
+    build_rate_limit_text,
     get_bot_url,
-    make_status_text_progress_updater,
     remove_file,
     safe_answer_inline_query,
     safe_edit_inline_media,
     safe_edit_inline_text,
 )
 from services.logger import logger as logging, summarize_text_for_log
+from services.inline.send_flow import (
+    VIDEO_TOO_LARGE,
+    deliver_inline_video,
+    run_inline_send_flow,
+)
 from services.inline.service_icons import get_inline_service_icon
 from services.inline.video_requests import (
     claim_inline_video_request_for_send,
@@ -30,13 +36,14 @@ from services.media.delivery import (
     coerce_audio_duration_seconds,
     send_audio_with_thumbnail,
 )
+from services.media.audio_flow import run_audio_flow
 from services.media.audio_metadata import build_audio_filename, prepare_mp3_metadata
-from services.media.video_metadata import build_video_send_kwargs
 from services.platforms.youtube_media import (
     YOUTUBE_INFO_TIMEOUT_SECONDS,
     get_audio_artist,
     get_youtube_thumbnail_url,
 )
+from utils.download_manager import DownloadQueueBusyError, DownloadRateLimitError
 from utils.media_cache import build_media_cache_key
 
 logging = logging.bind(service="youtube_inline")
@@ -187,9 +194,6 @@ async def send_inline_youtube_music(
     if request is None:
         return
 
-    metrics = None
-    prepared_metadata = None
-
     _edit_inline_status = build_inline_status_editor(
         bot=deps.bot,
         inline_message_id=inline_message_id,
@@ -209,12 +213,16 @@ async def send_inline_youtube_music(
         audio_artist = get_audio_artist(yt)
         thumbnail_url = get_youtube_thumbnail_url(yt)
         cache_key = build_media_cache_key(request.source_url, variant=AUDIO_CACHE_VARIANT)
-        db_file_id = await deps.db.get_file_id(cache_key)
         bot_url = await get_bot_url_fn(deps.bot)
-        if not db_file_id:
+
+        async def _send_cached(_file_id: str):
+            await _edit_inline_status(bm.uploading_status())
+            return None
+
+        async def _download_audio():
             base_name = f"{yt.get('id', 'youtube_music')}_youtube_music_inline"
             await _edit_inline_status(bm.downloading_audio_status())
-            metrics = await retry_async_operation_fn(
+            return await retry_async_operation_fn(
                 lambda: download_mp3_with_ytdlp_metrics_fn(
                     request.source_url,
                     base_name,
@@ -225,17 +233,18 @@ async def send_inline_youtube_music(
                 delay_seconds=2.0,
                 should_retry_result=lambda result: result is None,
             )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
-            if metrics.size >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.audio_too_large())
-                return
 
-            prepared_metadata = await prepare_mp3_metadata(
-                metrics.path,
+        async def _on_missing_audio():
+            reset_inline_video_request(token)
+            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
+
+        async def _on_too_large():
+            complete_inline_video_request(token)
+            await _edit_inline_status(bm.audio_too_large())
+
+        async def _prepare_metadata(path: str):
+            return await prepare_mp3_metadata(
+                path,
                 {
                     **yt,
                     "artists": audio_artist,
@@ -245,6 +254,7 @@ async def send_inline_youtube_music(
                 },
             )
 
+        async def _send_downloaded(path: str, prepared_metadata):
             await _edit_inline_status(bm.uploading_status())
             bot_avatar = await get_bot_avatar_thumbnail_fn(deps.bot)
             audio_thumbnail = (
@@ -252,32 +262,43 @@ async def send_inline_youtube_music(
                 if prepared_metadata.thumbnail_path
                 else bot_avatar
             )
-            sent = await send_audio_with_thumbnail(
+            return await send_audio_with_thumbnail(
                 deps.bot.send_audio,
                 chat_id=channel_id,
                 audio=FSInputFile(
-                    metrics.path,
+                    path,
                     filename=build_audio_filename(yt.get("title")),
                 ),
                 title=yt.get("title"),
                 performer=audio_artist,
                 caption=f"YouTube Music from {actor_name}",
-                audio_path=metrics.path,
+                audio_path=path,
                 bot_avatar=audio_thumbnail,
                 bot_url=bot_url,
                 duration=audio_duration,
                 embed_thumbnail=False,
             )
-            db_file_id = sent.audio.file_id
-            await deps.db.add_file(cache_key, db_file_id, "audio")
-        else:
-            await _edit_inline_status(bm.uploading_status())
+
+        result = await run_audio_flow(
+            cache_key=cache_key,
+            db_service=deps.db,
+            send_cached=_send_cached,
+            download_audio=_download_audio,
+            on_missing_audio=_on_missing_audio,
+            max_file_size=max_file_size,
+            on_too_large=_on_too_large,
+            prepare_metadata=_prepare_metadata,
+            send_downloaded=_send_downloaded,
+            cleanup_path=remove_file,
+        )
+        if result is None:
+            return
 
         edited = await safe_edit_inline_media_fn(
             deps.bot,
             inline_message_id,
             types.InputMediaAudio(
-                media=db_file_id,
+                media=result.file_id,
                 caption=bm.captions(request.user_settings["captions"], None, bot_url),
                 performer=audio_artist or build_bot_audio_performer(bot_url),
                 duration=audio_duration,
@@ -290,14 +311,24 @@ async def send_inline_youtube_music(
 
         reset_inline_video_request(token)
         await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
+    except DownloadRateLimitError as exc:
+        reset_inline_video_request(token)
+        await _edit_inline_status(build_rate_limit_text(exc.retry_after), with_retry_button=True)
+    except DownloadQueueBusyError as exc:
+        reset_inline_video_request(token)
+        await _edit_inline_status(build_queue_busy_text(exc.position), with_retry_button=True)
     except asyncio.TimeoutError:
         reset_inline_video_request(token)
         await _edit_inline_status(bm.timeout_error(), with_retry_button=True)
-    finally:
-        if prepared_metadata:
-            prepared_metadata.cleanup()
-        if metrics and metrics.path:
-            await remove_file(metrics.path)
+    except Exception as exc:
+        logging.exception(
+            "Error sending inline YouTube Music audio: inline_message_id=%s token=%s error=%s",
+            inline_message_id,
+            token,
+            exc,
+        )
+        reset_inline_video_request(token)
+        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
 
 
 async def send_inline_youtube_video(
@@ -322,47 +353,58 @@ async def send_inline_youtube_video(
     safe_edit_inline_media_fn=safe_edit_inline_media,
     safe_edit_inline_text_fn=safe_edit_inline_text,
 ) -> None:
-    request = claim_inline_video_request_for_send(
-        token,
-        duplicate_handler=duplicate_handler,
-        actor_user_id=actor_user_id,
-    )
-    if request is None:
-        return
-
-    metrics = None
-
-    _edit_inline_status = build_inline_status_editor(
-        bot=deps.bot,
-        inline_message_id=inline_message_id,
-        callback_data_factory=lambda _media_kind: f"inline:youtube:{token}",
-        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
-        button_text="Send video inline",
-    )
-
-    try:
+    async def _plan(request, edit_status, state) -> None:
         yt = await _get_youtube_video_with_timeout(get_youtube_video_fn, request.source_url)
         if not yt:
             reset_inline_video_request(token)
-            await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True)
             return
 
         views = safe_int_fn(yt.get("view_count"), 0)
         likes = safe_int_fn(yt.get("like_count"), 0)
-        db_file_id = await deps.db.get_file_id(request.source_url)
-        if not db_file_id:
+
+        async def _build_caption():
+            return bm.captions(
+                request.user_settings["captions"],
+                yt["title"],
+                await get_bot_url_fn(deps.bot),
+            )
+
+        async def _download(on_progress):
             video = await asyncio.to_thread(get_video_stream_fn, yt)
 
             name = f"{yt['id']}_youtube_inline.mp4"
             inline_size_hint_raw = (video or {}).get("filesize") or (video or {}).get("filesize_approx")
             inline_size_hint = safe_int_fn(inline_size_hint_raw, 0) or None
             if inline_size_hint and inline_size_hint >= max_file_size:
-                complete_inline_video_request(token)
-                await _edit_inline_status(bm.video_too_large())
-                return
+                return VIDEO_TOO_LARGE
 
-            await _edit_inline_status(bm.downloading_video_status())
             if not video:
+                return await download_with_ytdlp_metrics_fn(
+                    request.source_url,
+                    name,
+                    ytdlp_format_720,
+                    "youtube_inline_ytdlp_merged",
+                    max_filesize=max_file_size - 1,
+                )
+            if is_manifest_stream_fn(video):
+                return await download_with_ytdlp_metrics_fn(
+                    request.source_url,
+                    name,
+                    ytdlp_format_720,
+                    "youtube_inline_ytdlp_manifest",
+                    max_filesize=max_file_size - 1,
+                )
+            metrics = await download_stream_fn(
+                video,
+                name,
+                "youtube_inline",
+                user_id=request.owner_user_id,
+                size_hint=inline_size_hint,
+                max_size_bytes=max_file_size,
+                on_progress=on_progress,
+            )
+            if not metrics:
                 metrics = await download_with_ytdlp_metrics_fn(
                     request.source_url,
                     name,
@@ -370,59 +412,20 @@ async def send_inline_youtube_video(
                     "youtube_inline_ytdlp_merged",
                     max_filesize=max_file_size - 1,
                 )
-            elif is_manifest_stream_fn(video):
-                metrics = await download_with_ytdlp_metrics_fn(
-                    request.source_url,
-                    name,
-                    ytdlp_format_720,
-                    "youtube_inline_ytdlp_manifest",
-                    max_filesize=max_file_size - 1,
-                )
-            else:
-                on_progress = make_status_text_progress_updater("YouTube video", _edit_inline_status)
-                metrics = await download_stream_fn(
-                    video,
-                    name,
-                    "youtube_inline",
-                    user_id=request.owner_user_id,
-                    size_hint=inline_size_hint,
-                    max_size_bytes=max_file_size,
-                    on_progress=on_progress,
-                )
-                if not metrics:
-                    metrics = await download_with_ytdlp_metrics_fn(
-                        request.source_url,
-                        name,
-                        ytdlp_format_720,
-                        "youtube_inline_ytdlp_merged",
-                        max_filesize=max_file_size - 1,
-                    )
-            if not metrics:
-                reset_inline_video_request(token)
-                await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-                return
+            return metrics
 
-            await _edit_inline_status(bm.uploading_status())
-            sent_message = await deps.bot.send_video(
-                chat_id=channel_id,
-                video=FSInputFile(metrics.path),
-                caption=f"YouTube Video from {actor_name}",
-                **(await build_video_send_kwargs(metrics.path)),
-            )
-            db_file_id = sent_message.video.file_id
-            await deps.db.add_file(request.source_url, db_file_id, "video")
-        else:
-            await _edit_inline_status(bm.uploading_status())
-
-        bot_url = await get_bot_url_fn(deps.bot)
-        edited = await safe_edit_inline_media_fn(
-            deps.bot,
-            inline_message_id,
-            types.InputMediaVideo(
-                media=db_file_id,
-                caption=bm.captions(request.user_settings["captions"], yt["title"], bot_url),
-                parse_mode="HTML",
-            ),
+        await deliver_inline_video(
+            deps=deps,
+            token=token,
+            inline_message_id=inline_message_id,
+            channel_id=channel_id,
+            max_file_size=max_file_size,
+            service_name="YouTube",
+            cache_key=request.source_url,
+            channel_caption=f"YouTube Video from {actor_name}",
+            download_fn=_download,
+            progress_label="YouTube video",
+            build_caption=_build_caption,
             reply_markup=kb.return_video_info_keyboard(
                 views=views,
                 likes=likes,
@@ -432,16 +435,23 @@ async def send_inline_youtube_video(
                 video_url=request.source_url,
                 user_settings=request.user_settings,
             ),
+            edit_status=edit_status,
+            state=state,
+            safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+            metrics_log_key=None,
+            log=logging,
         )
-        if edited:
-            complete_inline_video_request(token)
-            return
 
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.something_went_wrong(), with_retry_button=True)
-    except asyncio.TimeoutError:
-        reset_inline_video_request(token)
-        await _edit_inline_status(bm.timeout_error(), with_retry_button=True)
-    finally:
-        if metrics and metrics.path:
-            await remove_file(metrics.path)
+    await run_inline_send_flow(
+        token=token,
+        inline_message_id=inline_message_id,
+        actor_user_id=actor_user_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service_name="YouTube",
+        callback_data=f"inline:youtube:{token}",
+        plan_fn=_plan,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        button_text="Send video inline",
+        log=logging,
+    )

--- a/keyboards/inline_keyboards.py
+++ b/keyboards/inline_keyboards.py
@@ -201,38 +201,6 @@ def downloads_admin_keyboard(can_cleanup: bool = True, refresh_callback: str = "
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
-def return_search_keyboard():
-    buttons = [
-        [
-            InlineKeyboardButton(text="ID", callback_data="search_id"),
-            InlineKeyboardButton(text="Username", callback_data="search_username"),
-        ],
-        [InlineKeyboardButton(text="⬅️ Back", callback_data="back_to_admin")],
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
-
-
-def return_control_user_keyboard(user_id, status):
-    builder = InlineKeyboardBuilder()
-
-    go_to_chat = InlineKeyboardButton(text="Open Chat", url=f"tg://user?id={user_id}")
-    write_user = InlineKeyboardButton(text="Write as Bot", callback_data=f"write_{user_id}")
-    ban_button = InlineKeyboardButton(text="Ban", callback_data=f"ban_{user_id}")
-    unban_button = InlineKeyboardButton(text="Unban", callback_data=f"unban_{user_id}")
-    back_button = InlineKeyboardButton(text="⬅️ Back", callback_data="back_to_admin")
-
-    builder.row(go_to_chat, write_user)
-
-    if status == "active":
-        builder.row(ban_button)
-    elif status == "ban":
-        builder.row(unban_button)
-
-    builder.row(back_button)
-
-    return builder.as_markup()
-
-
 def return_back_to_admin_keyboard():
     back_button = [
         [InlineKeyboardButton(text="⬅️ Back", callback_data="back_to_admin")]

--- a/main.py
+++ b/main.py
@@ -352,10 +352,11 @@ async def main():
 
             dp.include_router(handlers.router)
 
-            for middleware in middlewares.__all__:
-                dp.message.outer_middleware(middleware())
-                dp.callback_query.outer_middleware(middleware())
-                dp.inline_query.outer_middleware(middleware())
+            for middleware_cls in middlewares.__all__:
+                middleware = middleware_cls()
+                dp.message.outer_middleware(middleware)
+                dp.callback_query.outer_middleware(middleware)
+                dp.inline_query.outer_middleware(middleware)
 
             await bot.set_my_commands(commands=BOT_COMMANDS)
             await bot.delete_webhook(drop_pending_updates=True)

--- a/messages/__init__.py
+++ b/messages/__init__.py
@@ -1,13 +1,21 @@
 from . import admin_messages as _admin_messages
 from . import user_messages as _user_messages
 
-_exported_names = {
-    name for name in dir(_admin_messages) if not name.startswith("_")
-}
-_exported_names.update(
-    name for name in dir(_user_messages) if not name.startswith("_")
-)
-__all__ = sorted(_exported_names)
+_admin_names = {name for name in dir(_admin_messages) if not name.startswith("_")}
+_user_names = {name for name in dir(_user_messages) if not name.startswith("_")}
 
-globals().update({name: getattr(_admin_messages, name) for name in dir(_admin_messages) if name in __all__})
-globals().update({name: getattr(_user_messages, name) for name in dir(_user_messages) if name in __all__})
+# Names deliberately defined in both modules; the user_messages variant wins in the
+# merged namespace. Import `messages.admin_messages` directly for the admin variant.
+_ALLOWED_SHADOWED_NAMES = {"something_went_wrong"}
+
+_unexpected_collisions = (_admin_names & _user_names) - _ALLOWED_SHADOWED_NAMES
+if _unexpected_collisions:
+    raise RuntimeError(
+        "Message name(s) defined in both admin_messages and user_messages would be "
+        "silently shadowed: " + ", ".join(sorted(_unexpected_collisions))
+    )
+
+__all__ = sorted(_admin_names | _user_names)
+
+globals().update({name: getattr(_admin_messages, name) for name in _admin_names})
+globals().update({name: getattr(_user_messages, name) for name in _user_names})

--- a/messages/admin_messages.py
+++ b/messages/admin_messages.py
@@ -27,10 +27,6 @@ def start_mailing():
     return "Starting mailing..."
 
 
-def mailing_message():
-    return "Enter the message to send:"
-
-
 def mailing_audience_preview(total_users, active_users, inactive_users, banned_users, private_users, group_users):
     return ("""<b>Mailing audience preview</b>
 Users to process: <b>{total_users}</b>
@@ -50,31 +46,6 @@ Enter the message to send:""").format(
     )
 
 
-def search_user_by():
-    return "Search user by:"
-
-
-def type_user(search):
-    return f"Type user {search}:"
-
-
-def user_not_found():
-    return "User not found!"
-
-
-def return_user_info(user_name, user_id, user_username, status):
-    return ("""<b>USER INFO</b>
-<b>Name</b>: {user_name}
-<b>ID</b>: {user_id}
-<b>Username</b>: {user_username}
-<b>Status</b>: {status}""").format(
-        user_name=user_name,
-        user_id=user_id,
-        user_username=user_username,
-        status=status,
-    )
-
-
 def canceled():
     return "Action canceled!"
 
@@ -85,26 +56,6 @@ def your_message_sent():
 
 def something_went_wrong():
     return "Something went wrong, see log for more information!"
-
-
-def enter_ban_reason():
-    return "Enter ban reason:"
-
-
-def successful_ban(banned_user_id):
-    return f"User {banned_user_id} successfully banned!"
-
-
-def successful_unban(unbanned_user_id):
-    return f"User {unbanned_user_id} successfully unbanned!"
-
-
-def ban_message(reason):
-    return f"You have been banned, contact @mak5er for more information!\nReason: {reason}"
-
-
-def unban_message():
-    return "You have been unbanned!"
 
 
 def please_type_message():

--- a/services/alembic/versions/20260726_000010_drop_redundant_analytics_indexes.py
+++ b/services/alembic/versions/20260726_000010_drop_redundant_analytics_indexes.py
@@ -1,0 +1,48 @@
+"""Drop redundant analytics_events indexes.
+
+ix_analytics_events_created_at is a left-prefix of ix_analytics_events_created_action
+and ix_analytics_events_action_name is a left-prefix of
+ix_analytics_events_action_name_created_at, so both are redundant and only add
+write overhead on the hottest insert table.
+
+Revision ID: 20260726_000010
+Revises: 20260722_000009
+Create Date: 2026-07-26 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260726_000010"
+down_revision: Union[str, Sequence[str], None] = "20260722_000009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+REDUNDANT_INDEXES: tuple[tuple[str, str, list[str]], ...] = (
+    ("ix_analytics_events_created_at", "analytics_events", ["created_at"]),
+    ("ix_analytics_events_action_name", "analytics_events", ["action_name"]),
+)
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    index_names = {index["name"] for index in inspector.get_indexes(table_name)}
+    return index_name in index_names
+
+
+def upgrade() -> None:
+    for index_name, table_name, _columns in REDUNDANT_INDEXES:
+        if _has_index(table_name, index_name):
+            op.drop_index(index_name, table_name=table_name)
+
+
+def downgrade() -> None:
+    for index_name, table_name, columns in reversed(REDUNDANT_INDEXES):
+        if not _has_index(table_name, index_name):
+            op.create_index(index_name, table_name, columns, unique=False)

--- a/services/download/queue.py
+++ b/services/download/queue.py
@@ -25,6 +25,8 @@ logging = logging.bind(service="download_queue")
 
 T = TypeVar("T")
 
+_SCOPE_PRUNE_INTERVAL_SECONDS = 60.0
+
 
 class QueueRateLimitError(Exception):
     def __init__(self, retry_after: float):
@@ -153,6 +155,7 @@ class AdaptiveDownloadQueue:
         self._scale_cooldown_seconds = max(1.0, float(DOWNLOAD_QUEUE_SCALE_COOLDOWN_SECONDS))
         self._idle_scale_down_seconds = max(5.0, float(DOWNLOAD_QUEUE_IDLE_SCALE_DOWN_SECONDS))
         self._last_non_empty_queue = time.monotonic()
+        self._last_scope_prune = time.monotonic()
         self._completed_jobs = 0
         self._active_jobs = 0
 
@@ -467,6 +470,9 @@ class AdaptiveDownloadQueue:
         if self._stopping:
             return
         now = time.monotonic()
+        if now - self._last_scope_prune >= _SCOPE_PRUNE_INTERVAL_SECONDS:
+            self._last_scope_prune = now
+            self._prune_idle_scopes()
         if now - self._last_scale_action < self._scale_cooldown_seconds:
             return
 
@@ -538,6 +544,45 @@ class AdaptiveDownloadQueue:
             raise QueueRateLimitError(retry_after=retry_after)
 
         bucket.append(now)
+
+    def _prune_idle_scopes(self) -> None:
+        """Drop per-scope rate/slot/lock state that is no longer in use.
+
+        Without this, _user_recent/_user_slots/_user_submit_locks gain an
+        entry per unique (user_id, chat_id) forever. Only fully idle scopes
+        are removed: no pending jobs, no in-flight request refs, an unheld
+        submit lock and an expired rate window — which also rules out tasks
+        that were woken on the lock/semaphore but have not resumed yet.
+        This runs synchronously on the event loop, so it cannot interleave
+        with submit()'s critical sections.
+        """
+        now = time.monotonic()
+        for scope_key, bucket in list(self._user_recent.items()):
+            while bucket and now - bucket[0] > self.per_user_window_seconds:
+                bucket.popleft()
+            if not bucket:
+                del self._user_recent[scope_key]
+
+        active_request_scopes = {request_key[0] for request_key in self._request_refs}
+        for scope_key in self._user_slots.keys() | self._user_submit_locks.keys():
+            if not self._scope_is_idle(scope_key, active_request_scopes):
+                continue
+            self._user_slots.pop(scope_key, None)
+            self._user_submit_locks.pop(scope_key, None)
+
+    def _scope_is_idle(
+        self,
+        scope_key: _QueueScopeKey,
+        active_request_scopes: set[_QueueScopeKey],
+    ) -> bool:
+        if self._user_pending.get(scope_key, 0) > 0:
+            return False
+        if scope_key in active_request_scopes:
+            return False
+        if scope_key in self._user_recent:
+            return False
+        lock = self._user_submit_locks.get(scope_key)
+        return lock is None or not lock.locked()
 
     @staticmethod
     def _build_scope_key(user_id: int, chat_id: Optional[int]) -> _QueueScopeKey:

--- a/services/download/worker_cli.py
+++ b/services/download/worker_cli.py
@@ -4,6 +4,7 @@ import json
 import sys
 from dataclasses import asdict
 
+from services.logger import disable_log_sinks
 from utils.download_manager import DownloadConfig, ResilientDownloader
 
 
@@ -23,6 +24,11 @@ def _build_config(raw: dict) -> DownloadConfig:
 
 
 def main() -> int:
+    # The parent process raises this worker's entire stderr as the download
+    # error message and shares its log files, so drop every log sink first:
+    # stderr must carry only the final exception text, and a second process
+    # must not write/rotate the parent's rotating log files.
+    disable_log_sinks()
     try:
         payload = _read_payload()
         config = _build_config(payload.get("config") or {})

--- a/services/inline/send_flow.py
+++ b/services/inline/send_flow.py
@@ -1,0 +1,629 @@
+"""Shared inline send flow used by the *_inline handler modules.
+
+The cached-photo delivery, video download+send mechanics, album-preview
+caching and the canonical error tail (rate limit / queue busy / timeout /
+generic failure) live here exactly once. Each platform module supplies
+fetch/caption/keyboard callables and keeps its public entry points as thin
+orchestrations on top of these helpers.
+
+NOTE: helpers from the handlers package are imported lazily (see
+``_handler_utils``) because ``handlers/__init__.py`` imports every handler
+module and those modules import this one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+from typing import Any, Awaitable, Callable, List, Optional
+
+from aiogram import types
+from aiogram.types import FSInputFile
+
+import keyboards as kb
+import messages as bm
+from services.logger import logger, summarize_text_for_log, summarize_url_for_log
+from services.inline.album_links import create_inline_album_request
+from services.inline.service_icons import get_inline_service_icon
+from services.inline.video_requests import (
+    claim_inline_video_request_for_send,
+    complete_inline_video_request,
+    create_inline_video_request,
+    reset_inline_video_request,
+)
+from services.media.video_metadata import build_video_send_kwargs
+from utils.download_manager import (
+    DownloadQueueBusyError,
+    DownloadRateLimitError,
+    log_download_metrics,
+)
+from utils.media_cache import build_media_cache_key
+
+logging = logger.bind(service="inline_send_flow")
+
+StatusEditor = Callable[..., Awaitable[None]]
+
+#: Sentinel a ``download_fn`` may return to signal that the media is known to
+#: exceed the size limit before (or instead of) downloading it.
+VIDEO_TOO_LARGE = object()
+
+
+def _handler_utils():
+    """Deferred import of handler helpers to avoid a circular import."""
+    from handlers import utils as handler_utils
+
+    return handler_utils
+
+
+class InlineFlowState:
+    """Mutable state shared between a platform plan and the flow cleanup."""
+
+    def __init__(self) -> None:
+        self.cleanup_paths: List[str] = []
+        self.cleanup_callbacks: List[Callable[[], Any]] = []
+
+    def register_download_path(self, path: Optional[str]) -> None:
+        if path:
+            self.cleanup_paths.append(path)
+
+    def register_cleanup(self, callback: Callable[[], Any]) -> None:
+        self.cleanup_callbacks.append(callback)
+
+
+async def run_inline_send_flow(
+    *,
+    token: str,
+    inline_message_id: str,
+    actor_user_id: int,
+    duplicate_handler: str,
+    deps,
+    service_name: str,
+    callback_data: str,
+    plan_fn: Callable[[Any, StatusEditor, InlineFlowState], Awaitable[None]],
+    safe_edit_inline_text_fn,
+    button_text: Optional[str] = None,
+    log=None,
+) -> None:
+    """Claim the inline request, run ``plan_fn`` and apply the canonical
+    error tail (rate limit / queue busy / timeout / generic failure)."""
+    request = claim_inline_video_request_for_send(
+        token,
+        duplicate_handler=duplicate_handler,
+        actor_user_id=actor_user_id,
+    )
+    if request is None:
+        return
+
+    log = log or logging
+    utils = _handler_utils()
+    state = InlineFlowState()
+    edit_status = utils.build_inline_status_editor(
+        bot=deps.bot,
+        inline_message_id=inline_message_id,
+        callback_data_factory=lambda _media_kind: callback_data,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        button_text=button_text,
+    )
+
+    try:
+        await plan_fn(request, edit_status, state)
+    except DownloadRateLimitError as exc:
+        reset_inline_video_request(token)
+        await edit_status(utils.build_rate_limit_text(exc.retry_after), with_retry_button=True)
+    except DownloadQueueBusyError as exc:
+        reset_inline_video_request(token)
+        await edit_status(utils.build_queue_busy_text(exc.position), with_retry_button=True)
+    except asyncio.TimeoutError:
+        reset_inline_video_request(token)
+        await edit_status(bm.timeout_error(), with_retry_button=True)
+    except Exception as exc:
+        log.exception(
+            "Error sending inline %s media: inline_message_id=%s token=%s error=%s",
+            service_name,
+            inline_message_id,
+            token,
+            exc,
+        )
+        reset_inline_video_request(token)
+        await edit_status(bm.something_went_wrong(), with_retry_button=True)
+    finally:
+        for callback in state.cleanup_callbacks:
+            callback()
+        for path in state.cleanup_paths:
+            await utils.remove_file(path)
+
+
+async def deliver_inline_photo(
+    *,
+    deps,
+    token: str,
+    inline_message_id: str,
+    channel_id: Optional[int],
+    service_name: str,
+    cache_key: str,
+    photo_url: str,
+    channel_caption: str,
+    build_caption: Callable[[], Awaitable[Optional[str]]],
+    reply_markup,
+    edit_status: StatusEditor,
+    safe_edit_inline_media_fn,
+    log=None,
+) -> None:
+    """Serve a single photo inline, uploading it to the cache channel once."""
+    log = log or logging
+    db_id = await deps.db.get_file_id(cache_key)
+    if not db_id:
+        if not channel_id:
+            log.error("CHANNEL_ID is not configured; %s inline upload is disabled", service_name)
+            reset_inline_video_request(token)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
+            return
+
+        await edit_status(bm.uploading_status(), media_kind="photo")
+        sent = await deps.bot.send_photo(
+            chat_id=channel_id,
+            photo=photo_url,
+            caption=channel_caption,
+        )
+        if not sent.photo:
+            reset_inline_video_request(token)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
+            return
+        db_id = sent.photo[-1].file_id
+        await deps.db.add_file(cache_key, db_id, "photo")
+    else:
+        await edit_status(bm.uploading_status(), media_kind="photo")
+
+    edited = await safe_edit_inline_media_fn(
+        deps.bot,
+        inline_message_id,
+        types.InputMediaPhoto(
+            media=db_id,
+            caption=await build_caption(),
+            parse_mode="HTML",
+        ),
+        reply_markup=reply_markup,
+    )
+    if edited:
+        complete_inline_video_request(token)
+        return
+
+    reset_inline_video_request(token)
+    await edit_status(bm.something_went_wrong(), with_retry_button=True, media_kind="photo")
+
+
+async def deliver_inline_video(
+    *,
+    deps,
+    token: str,
+    inline_message_id: str,
+    channel_id: Optional[int],
+    max_file_size: int,
+    service_name: str,
+    cache_key: str,
+    channel_caption: str,
+    download_fn: Callable[[Callable[..., Awaitable[None]]], Awaitable[Any]],
+    progress_label: str,
+    build_caption: Callable[[], Awaitable[Optional[str]]],
+    reply_markup,
+    edit_status: StatusEditor,
+    state: InlineFlowState,
+    safe_edit_inline_media_fn,
+    metrics_log_key: Optional[str] = None,
+    log=None,
+) -> None:
+    """Serve a single video inline, downloading and uploading it to the cache
+    channel once. ``download_fn`` receives an ``on_progress`` callback and
+    returns download metrics, ``None`` on failure, or ``VIDEO_TOO_LARGE``."""
+    log = log or logging
+    utils = _handler_utils()
+    db_id = await deps.db.get_file_id(cache_key)
+    if not db_id:
+        if not channel_id:
+            log.error("CHANNEL_ID is not configured; %s inline upload is disabled", service_name)
+            reset_inline_video_request(token)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True)
+            return
+
+        await edit_status(bm.downloading_video_status())
+        on_progress = utils.make_status_text_progress_updater(progress_label, edit_status)
+        metrics = await download_fn(on_progress)
+        if metrics is VIDEO_TOO_LARGE:
+            complete_inline_video_request(token)
+            await edit_status(bm.video_too_large())
+            return
+        if not metrics:
+            reset_inline_video_request(token)
+            await edit_status(bm.something_went_wrong(), with_retry_button=True)
+            return
+
+        if metrics_log_key:
+            log_download_metrics(metrics_log_key, metrics)
+        state.register_download_path(metrics.path)
+        if metrics.size >= max_file_size:
+            complete_inline_video_request(token)
+            await edit_status(bm.video_too_large())
+            return
+
+        await edit_status(bm.uploading_status())
+        sent = await deps.bot.send_video(
+            chat_id=channel_id,
+            video=FSInputFile(metrics.path),
+            caption=channel_caption,
+            **(await build_video_send_kwargs(metrics.path)),
+        )
+        db_id = sent.video.file_id
+        await deps.db.add_file(cache_key, db_id, "video")
+        log.info(
+            "Inline %s video cached: url=%s file_id=%s",
+            service_name,
+            summarize_url_for_log(cache_key),
+            db_id,
+        )
+    else:
+        await edit_status(bm.uploading_status())
+
+    edited = await safe_edit_inline_media_fn(
+        deps.bot,
+        inline_message_id,
+        types.InputMediaVideo(
+            media=db_id,
+            caption=await build_caption(),
+            parse_mode="HTML",
+        ),
+        reply_markup=reply_markup,
+    )
+    if edited:
+        complete_inline_video_request(token)
+        log.info(
+            "Served inline %s video: inline_message_id=%s url=%s file_id=%s",
+            service_name,
+            inline_message_id,
+            summarize_url_for_log(cache_key),
+            db_id,
+        )
+        return
+
+    reset_inline_video_request(token)
+    await edit_status(bm.something_went_wrong(), with_retry_button=True)
+
+
+async def ensure_album_preview_file_id(
+    *,
+    deps,
+    channel_id: Optional[int],
+    photo_url: Optional[str],
+    cache_key: str,
+    service_name: str,
+    source_url: str,
+    log=None,
+) -> Optional[str]:
+    """Return a cached Telegram file_id for an album preview photo, uploading
+    it to the cache channel on first use. Best effort: returns ``None`` when
+    the preview cannot be prepared."""
+    if not channel_id or not photo_url:
+        return None
+    preview_file_id = await deps.db.get_file_id(cache_key)
+    if preview_file_id:
+        return preview_file_id
+    try:
+        sent = await deps.bot.send_photo(
+            chat_id=channel_id,
+            photo=photo_url,
+            caption=f"{service_name} Album Preview",
+        )
+        if sent.photo:
+            preview_file_id = sent.photo[-1].file_id
+            await deps.db.add_file(cache_key, preview_file_id, "photo")
+    except Exception as exc:
+        (log or logging).warning(
+            "Failed to cache %s album preview photo: url=%s error=%s",
+            service_name,
+            summarize_url_for_log(source_url),
+            exc,
+        )
+    return preview_file_id
+
+
+async def handle_post_inline_query(
+    query: types.InlineQuery,
+    *,
+    deps,
+    service,
+    url_regex: str,
+    strip_url_fn,
+    channel_id: Optional[int],
+    service_key: str,
+    service_name: str,
+    analytics_action: str,
+    get_preview_url,
+    allow_text_only: bool,
+    get_bot_url_fn,
+    safe_answer_inline_query_fn,
+    log=None,
+) -> None:
+    """Generic inline query handler for services exposing ``fetch_post``
+    returning a post with a ``media_list`` (Pinterest, Threads, ...)."""
+    import re
+
+    log = log or logging
+    try:
+        await deps.send_analytics(
+            user_id=query.from_user.id,
+            chat_type=query.chat_type,
+            action_name=analytics_action,
+        )
+        match = re.search(url_regex, query.query or "")
+        if not match:
+            await query.answer([], cache_time=1, is_personal=True)
+            return
+        source_url = strip_url_fn(match.group(0))
+        user_settings = await deps.db.user_settings(query.from_user.id)
+        bot_url = await get_bot_url_fn(deps.bot)
+
+        post = await service.fetch_post(source_url)
+        if not post:
+            await query.answer([], cache_time=1, is_personal=True)
+            return
+        if not post.media_list:
+            if not allow_text_only:
+                await query.answer([], cache_time=1, is_personal=True)
+                return
+            results = [
+                types.InlineQueryResultArticle(
+                    id=f"{service_key}_text_{post.id}",
+                    title=f"{service_name} Post",
+                    description=post.description or f"Text post from {service_name}.",
+                    thumbnail_url=get_inline_service_icon(service_key),
+                    input_message_content=types.InputTextMessageContent(
+                        message_text=bm.captions("on", post.description, bot_url, limit=4096),
+                        parse_mode="HTML",
+                    ),
+                    reply_markup=kb.return_video_info_keyboard(
+                        None, None, None, None, None, source_url, user_settings,
+                        audio_callback_data=None,
+                    ),
+                )
+            ]
+            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+            return
+        if not channel_id:
+            log.error("CHANNEL_ID is not configured; %s inline media is disabled", service_name)
+            await query.answer([], cache_time=1, is_personal=True)
+            return
+        first = post.media_list[0]
+        photo_items = [item for item in post.media_list if item.type == "photo"]
+        first_photo = photo_items[0] if photo_items else None
+        first_preview = get_preview_url(first) or next(
+            (get_preview_url(item) for item in post.media_list if get_preview_url(item)),
+            None,
+        )
+
+        if len(post.media_list) == 1 and first_photo:
+            token = create_inline_video_request(service_key, source_url, query.from_user.id, user_settings)
+            results = [
+                types.InlineQueryResultArticle(
+                    id=f"{service_key}_inline:{token}",
+                    title=f"{service_name} Photo",
+                    description=post.description or "Press the button to send this photo inline.",
+                    thumbnail_url=first_preview,
+                    input_message_content=types.InputTextMessageContent(
+                        message_text=f"{service_name} photo is being prepared...\nIf it does not start automatically, tap the button below.",
+                    ),
+                    reply_markup=kb.inline_send_media_keyboard(
+                        "Send photo inline",
+                        f"inline:{service_key}:{token}",
+                    ),
+                )
+            ]
+            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+            return
+
+        if len(post.media_list) > 1:
+            preview_file_id = None
+            if first.type == "photo":
+                preview_file_id = await ensure_album_preview_file_id(
+                    deps=deps,
+                    channel_id=channel_id,
+                    photo_url=first.url,
+                    cache_key=build_media_cache_key(source_url, item_index=0, item_kind="photo"),
+                    service_name=service_name,
+                    source_url=source_url,
+                    log=log,
+                )
+            token = create_inline_album_request(query.from_user.id, service_key, source_url)
+            utils = _handler_utils()
+            deep_link = utils.build_start_deeplink_url(bot_url, f"album_{token}")
+            results = [
+                utils.build_inline_album_result(
+                    result_id=f"{service_key}_album_{post.id}",
+                    service_name=service_name,
+                    deep_link=deep_link,
+                    message_text=bm.captions(user_settings["captions"], post.description, bot_url),
+                    preview_file_id=preview_file_id,
+                    preview_url=first_preview,
+                    thumbnail_url=first_preview or get_inline_service_icon(service_key),
+                )
+            ]
+            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+            return
+
+        if first.type != "video":
+            if first_photo:
+                preview_url = get_preview_url(first_photo)
+                results = [
+                    types.InlineQueryResultPhoto(
+                        id=f"{service_key}_photo_{post.id}",
+                        photo_url=first_photo.url,
+                        thumbnail_url=preview_url,
+                        title=bm.inline_photo_title(service_name),
+                        description=post.description or bm.inline_photo_description(),
+                        caption=bm.captions(user_settings["captions"], post.description, bot_url),
+                        reply_markup=kb.return_video_info_keyboard(
+                            None, None, None, None, None, source_url, user_settings,
+                            audio_callback_data=None,
+                        ),
+                        parse_mode="HTML",
+                    )
+                ]
+                await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+                return
+
+            results = [
+                types.InlineQueryResultArticle(
+                    id=f"unsupported_{service_key}_content",
+                    title=f"{service_name} Content",
+                    description="Only single videos are supported inline.",
+                    input_message_content=types.InputTextMessageContent(
+                        message_text=f"Only single {service_name} videos are supported inline.",
+                    ),
+                )
+            ]
+            await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+            return
+
+        token = create_inline_video_request(service_key, source_url, query.from_user.id, user_settings)
+        preview_url = get_preview_url(first) or get_inline_service_icon(service_key)
+        results = [
+            types.InlineQueryResultArticle(
+                id=f"{service_key}_inline:{token}",
+                title=f"{service_name} Video",
+                description=post.description or "Press the button to send this video inline.",
+                thumbnail_url=preview_url,
+                input_message_content=types.InputTextMessageContent(
+                    message_text=bm.inline_send_video_prompt(service_name),
+                ),
+                reply_markup=kb.inline_send_media_keyboard(
+                    "Send video inline",
+                    f"inline:{service_key}:{token}",
+                ),
+            )
+        ]
+        await safe_answer_inline_query_fn(query, results, cache_time=10, is_personal=True)
+    except Exception as exc:
+        log.exception(
+            "Error processing %s inline query: user_id=%s query=%s error=%s",
+            service_name,
+            query.from_user.id,
+            summarize_text_for_log(query.query),
+            exc,
+        )
+        await query.answer([], cache_time=1, is_personal=True)
+
+
+async def send_inline_post_media(
+    *,
+    token: str,
+    inline_message_id: str,
+    actor_name: str,
+    actor_user_id: int,
+    request_event_id: str,
+    duplicate_handler: str,
+    deps,
+    service,
+    channel_id: Optional[int],
+    max_file_size: int,
+    service_key: str,
+    service_name: str,
+    get_bot_url_fn,
+    safe_edit_inline_media_fn,
+    safe_edit_inline_text_fn,
+    log=None,
+) -> None:
+    """Generic inline send flow for services exposing ``fetch_post`` and
+    ``download_media`` (Pinterest, Threads, ...)."""
+    log = log or logging
+
+    async def _plan(request, edit_status, state: InlineFlowState) -> None:
+        post = await service.fetch_post(request.source_url)
+        if not post or len(post.media_list) != 1:
+            complete_inline_video_request(token)
+            await edit_status(bm.inline_photos_not_supported(service_name))
+            return
+
+        async def _build_caption() -> Optional[str]:
+            return bm.captions(
+                request.user_settings["captions"],
+                post.description,
+                await get_bot_url_fn(deps.bot),
+            )
+
+        reply_markup = kb.return_video_info_keyboard(
+            None,
+            None,
+            None,
+            None,
+            None,
+            request.source_url,
+            request.user_settings,
+            audio_callback_data=None,
+        )
+
+        first_item = post.media_list[0]
+        if first_item.type == "photo":
+            await deliver_inline_photo(
+                deps=deps,
+                token=token,
+                inline_message_id=inline_message_id,
+                channel_id=channel_id,
+                service_name=service_name,
+                cache_key=f"{request.source_url}#photo",
+                photo_url=first_item.url,
+                channel_caption=f"{service_name} Photo from {actor_name}",
+                build_caption=_build_caption,
+                reply_markup=reply_markup,
+                edit_status=edit_status,
+                safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+                log=log,
+            )
+            return
+
+        if first_item.type != "video":
+            complete_inline_video_request(token)
+            await edit_status(bm.inline_photos_not_supported(service_name))
+            return
+
+        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+        filename = f"{post.id}_{timestamp}_{service_key}_inline.mp4"
+
+        async def _download(on_progress):
+            return await service.download_media(
+                first_item.url,
+                filename,
+                user_id=request.owner_user_id,
+                request_id=f"{service_key}_inline:{request.owner_user_id}:{request_event_id}:{post.id}",
+                on_progress=on_progress,
+            )
+
+        await deliver_inline_video(
+            deps=deps,
+            token=token,
+            inline_message_id=inline_message_id,
+            channel_id=channel_id,
+            max_file_size=max_file_size,
+            service_name=service_name,
+            cache_key=request.source_url,
+            channel_caption=f"{service_name} Video from {actor_name}",
+            download_fn=_download,
+            progress_label=f"{service_name} video",
+            build_caption=_build_caption,
+            reply_markup=reply_markup,
+            edit_status=edit_status,
+            state=state,
+            safe_edit_inline_media_fn=safe_edit_inline_media_fn,
+            metrics_log_key=f"{service_key}_inline",
+            log=log,
+        )
+
+    await run_inline_send_flow(
+        token=token,
+        inline_message_id=inline_message_id,
+        actor_user_id=actor_user_id,
+        duplicate_handler=duplicate_handler,
+        deps=deps,
+        service_name=service_name,
+        callback_data=f"inline:{service_key}:{token}",
+        plan_fn=_plan,
+        safe_edit_inline_text_fn=safe_edit_inline_text_fn,
+        log=log,
+    )

--- a/services/logger.py
+++ b/services/logger.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import re
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from contextvars import ContextVar, Token
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
@@ -20,6 +20,12 @@ EVENT_LOG = os.path.join(LOG_DIR, "events_log.jsonl")
 PERF_LOG = os.path.join(LOG_DIR, "perf_log.jsonl")
 
 os.makedirs(LOG_DIR, exist_ok=True)
+
+_DISABLE_SINKS_ENV = "LOG_DISABLE_SINKS"
+
+
+def _sinks_disabled() -> bool:
+    return os.getenv(_DISABLE_SINKS_ENV, "").strip().lower() in {"1", "true", "yes"}
 
 _log_context: ContextVar[dict[str, Any]] = ContextVar("maxload_log_context", default={})
 
@@ -426,11 +432,14 @@ def _safe_add_handler(
         return False
 
 
-_base_logger.addHandler(_build_console_handler(logging.INFO))
-_safe_add_handler(lambda: _build_file_handler(INFO_LOG, logging.INFO), description="info file logger", path=INFO_LOG)
-_safe_add_handler(lambda: _build_file_handler(ERROR_LOG, logging.ERROR), description="error file logger", path=ERROR_LOG)
-_safe_add_handler(lambda: _build_json_handler(EVENT_LOG, "event"), description="event json logger", path=EVENT_LOG)
-_safe_add_handler(lambda: _build_json_handler(PERF_LOG, "perf"), description="perf json logger", path=PERF_LOG)
+if _sinks_disabled():
+    _base_logger.addHandler(logging.NullHandler())
+else:
+    _base_logger.addHandler(_build_console_handler(logging.INFO))
+    _safe_add_handler(lambda: _build_file_handler(INFO_LOG, logging.INFO), description="info file logger", path=INFO_LOG)
+    _safe_add_handler(lambda: _build_file_handler(ERROR_LOG, logging.ERROR), description="error file logger", path=ERROR_LOG)
+    _safe_add_handler(lambda: _build_json_handler(EVENT_LOG, "event"), description="event json logger", path=EVENT_LOG)
+    _safe_add_handler(lambda: _build_json_handler(PERF_LOG, "perf"), description="perf json logger", path=PERF_LOG)
 
 logger = ContextLoggerAdapter(_base_logger, {})
 
@@ -449,20 +458,45 @@ def get_log_context() -> dict[str, Any]:
     return dict(_log_context.get())
 
 
-def _configure_third_party_loggers() -> None:
-    noisy_loggers = {
-        "aiogram": logging.ERROR,
-        "aiogram.event": logging.CRITICAL,
-        "aiosqlite": logging.ERROR,
-        "httpcore": logging.WARNING,
-        "httpx": logging.WARNING,
-        "asyncio": logging.WARNING,
-    }
+_THIRD_PARTY_LOG_LEVELS = {
+    "aiogram": logging.ERROR,
+    "aiogram.event": logging.CRITICAL,
+    "aiosqlite": logging.ERROR,
+    "httpcore": logging.WARNING,
+    "httpx": logging.WARNING,
+    "asyncio": logging.WARNING,
+}
 
-    for name, level in noisy_loggers.items():
+
+def _configure_third_party_loggers() -> None:
+    for name, level in _THIRD_PARTY_LOG_LEVELS.items():
         third_party_logger = logging.getLogger(name)
         third_party_logger.setLevel(level)
         third_party_logger.propagate = False
+        # With propagate=False and no handlers of their own, surviving records
+        # (e.g. aiogram ERROR) would fall through to logging.lastResort — raw,
+        # unformatted stderr that never reaches the log files — so route them
+        # through the app's handlers explicitly.
+        for handler in _base_logger.handlers:
+            if handler not in third_party_logger.handlers:
+                third_party_logger.addHandler(handler)
+
+
+def disable_log_sinks() -> None:
+    """Detach and close every log sink for this process.
+
+    Used by short-lived worker subprocesses (services.download.worker_cli) so
+    they neither pollute stderr — which the parent process reads as the error
+    protocol — nor write/rotate the parent's log files from a second process.
+    """
+    os.environ[_DISABLE_SINKS_ENV] = "1"
+    targets = [_base_logger] + [logging.getLogger(name) for name in _THIRD_PARTY_LOG_LEVELS]
+    for target in targets:
+        for handler in list(target.handlers):
+            target.removeHandler(handler)
+            with suppress(Exception):
+                handler.close()
+    _base_logger.addHandler(logging.NullHandler())
 
 
 _configure_third_party_loggers()

--- a/services/media/audio_flow.py
+++ b/services/media/audio_flow.py
@@ -1,0 +1,94 @@
+"""Shared MP3 delivery pipeline used by the YouTube, SoundCloud and Spotify flows.
+
+``run_audio_flow`` mirrors ``run_single_media_flow``: cached-file lookup,
+optional metadata fetch, retryable download (supplied by the caller),
+size check, MP3 metadata preparation, upload, cache store, and temp-file
+cleanup in ``finally``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+from utils.download_manager import DownloadMetrics
+
+
+def _default_extract_file_id(sent: Any) -> Optional[str]:
+    audio = getattr(sent, "audio", None)
+    return audio.file_id if audio else None
+
+
+@dataclass
+class AudioFlowResult:
+    file_id: Optional[str]
+    sent_message: Any = None
+    from_cache: bool = False
+
+
+async def run_audio_flow(
+    *,
+    cache_key: str,
+    db_service: Any,
+    send_cached: Callable[[str], Awaitable[Any]],
+    download_audio: Callable[[], Awaitable[Optional[DownloadMetrics]]],
+    on_missing_audio: Callable[[], Awaitable[None]],
+    max_file_size: int,
+    on_too_large: Callable[[], Awaitable[None]],
+    prepare_metadata: Callable[[str], Awaitable[Any]],
+    send_downloaded: Callable[[str, Any], Awaitable[Any]],
+    cleanup_path: Callable[[str], Awaitable[None]],
+    fetch_metadata: Optional[Callable[[], Awaitable[bool]]] = None,
+    extract_file_id: Callable[[Any], Optional[str]] = _default_extract_file_id,
+    cache_file_type: str = "audio",
+    on_cache_store_error: Optional[Callable[[Exception], Awaitable[None]]] = None,
+    on_after_send: Optional[Callable[[AudioFlowResult], Awaitable[None]]] = None,
+) -> Optional[AudioFlowResult]:
+    """Run the shared audio pipeline and return the delivery result.
+
+    Returns ``None`` when the flow ended early (missing media, oversized
+    file, or an aborted ``fetch_metadata``); the corresponding callback has
+    already produced user feedback in that case. Backpressure and unexpected
+    errors propagate to the caller unchanged.
+    """
+    cached_file_id = await db_service.get_file_id(cache_key)
+    if cached_file_id:
+        sent = await send_cached(cached_file_id)
+        result = AudioFlowResult(
+            file_id=cached_file_id, sent_message=sent, from_cache=True
+        )
+        if on_after_send:
+            await on_after_send(result)
+        return result
+
+    if fetch_metadata is not None and not await fetch_metadata():
+        return None
+
+    metrics = await download_audio()
+    if not metrics:
+        await on_missing_audio()
+        return None
+
+    try:
+        if metrics.size >= max_file_size:
+            await on_too_large()
+            return None
+
+        prepared_metadata = await prepare_metadata(metrics.path)
+        try:
+            sent = await send_downloaded(metrics.path, prepared_metadata)
+            file_id = extract_file_id(sent)
+            if file_id:
+                try:
+                    await db_service.add_file(cache_key, file_id, cache_file_type)
+                except Exception as exc:
+                    if on_cache_store_error is None:
+                        raise
+                    await on_cache_store_error(exc)
+            result = AudioFlowResult(file_id=file_id, sent_message=sent)
+            if on_after_send:
+                await on_after_send(result)
+            return result
+        finally:
+            if prepared_metadata is not None:
+                prepared_metadata.cleanup()
+    finally:
+        await cleanup_path(metrics.path)

--- a/services/media/delivery.py
+++ b/services/media/delivery.py
@@ -2,13 +2,14 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from aiogram import types
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import FSInputFile
 from aiogram.utils.media_group import MediaGroupBuilder
 
-from services.logger import logger as logging
+from services.logger import logger as logging, summarize_url_for_log
 from services.media.artist_names import normalize_artist_names
 from services.media.video_metadata import build_video_send_kwargs
 
@@ -237,6 +238,73 @@ async def send_audio_with_thumbnail(
             Path(embedded_audio_path).unlink(missing_ok=True)
 
 
+def make_video_or_document_senders(
+    message: types.Message,
+    *,
+    caption: str | None,
+    reply_markup_fn: Callable[[], Any],
+    as_document: bool,
+    cached_log_label: str,
+    cached_log_url: str | None = None,
+    parse_mode: str = "HTML",
+) -> tuple[
+    Callable[[str], Awaitable[types.Message | None]],
+    Callable[[str], Awaitable[types.Message]],
+    Callable[[types.Message], str | None],
+]:
+    """Build the (send_cached, send_downloaded, extract_file_id) triple shared
+    by the single-video message flows: as_document switches reply_document
+    (with disable_content_type_detection) vs reply_video, and a cached send
+    that hits TelegramBadRequest resolves to None so the flow re-downloads."""
+
+    async def send_cached(file_id: str) -> types.Message | None:
+        logging.info(
+            "Serving cached %s: url=%s file_id=%s",
+            cached_log_label,
+            summarize_url_for_log(cached_log_url),
+            file_id,
+        )
+        try:
+            if as_document:
+                return await message.reply_document(
+                    document=file_id,
+                    caption=caption,
+                    reply_markup=reply_markup_fn(),
+                    parse_mode=parse_mode,
+                    disable_content_type_detection=True,
+                )
+            return await message.reply_video(
+                video=file_id,
+                caption=caption,
+                reply_markup=reply_markup_fn(),
+                parse_mode=parse_mode,
+            )
+        except TelegramBadRequest:
+            return None
+
+    async def send_downloaded(path: str) -> types.Message:
+        if as_document:
+            return await message.reply_document(
+                document=FSInputFile(path),
+                caption=caption,
+                reply_markup=reply_markup_fn(),
+                parse_mode=parse_mode,
+                disable_content_type_detection=True,
+            )
+        return await message.reply_video(
+            video=FSInputFile(path),
+            caption=caption,
+            reply_markup=reply_markup_fn(),
+            parse_mode=parse_mode,
+            **(await build_video_send_kwargs(path)),
+        )
+
+    def extract_file_id(sent_message: types.Message) -> str | None:
+        return extract_sent_file_id(sent_message, "video")
+
+    return send_cached, send_downloaded, extract_file_id
+
+
 def extract_sent_file_id(sent_message: types.Message, media_kind: str) -> str | None:
     if getattr(sent_message, "document", None):
         return sent_message.document.file_id
@@ -311,8 +379,21 @@ async def send_cached_media_entries(
         album_items = entries[:-1]
         for offset in range(0, len(album_items), 10):
             batch = album_items[offset:offset + 10]
+            video_kwargs_by_index: dict[int, dict[str, Any]] = {}
+            if not as_document:
+                video_indexes = [
+                    index
+                    for index, entry in enumerate(batch)
+                    if str(entry[kind_key]) == "video"
+                ]
+                if video_indexes:
+                    kwargs_list = await asyncio.gather(*(
+                        build_video_send_kwargs(str(batch[index].get(path_key)) if batch[index].get(path_key) else None)
+                        for index in video_indexes
+                    ))
+                    video_kwargs_by_index = dict(zip(video_indexes, kwargs_list))
             media_group = MediaGroupBuilder()
-            for entry in batch:
+            for index, entry in enumerate(batch):
                 media_kind = str(entry[kind_key])
                 media_ref = resolve_media_input(
                     entry,
@@ -325,7 +406,7 @@ async def send_cached_media_entries(
                 elif media_kind == "video":
                     media_group.add_video(
                         media=media_ref,
-                        **(await build_video_send_kwargs(str(entry.get(path_key)) if entry.get(path_key) else None)),
+                        **video_kwargs_by_index[index],
                     )
                 else:
                     media_group.add_photo(media=media_ref)
@@ -336,8 +417,8 @@ async def send_cached_media_entries(
             sent_group = await message.answer_media_group(**send_kwargs)
             has_sent_media = True
 
-            for sent_message, entry in zip(sent_group, batch):
-                await _cache_sent_entry(
+            await asyncio.gather(*(
+                _cache_sent_entry(
                     db_service,
                     entry,
                     sent_message,
@@ -345,6 +426,8 @@ async def send_cached_media_entries(
                     cache_key_key=cache_key_key,
                     cached_key=cached_key,
                 )
+                for sent_message, entry in zip(sent_group, batch)
+            ))
 
     last_entry = entries[-1]
     media_kind = str(last_entry[kind_key])

--- a/services/media/orchestration.py
+++ b/services/media/orchestration.py
@@ -1,6 +1,7 @@
 import asyncio
-from typing import Any, Awaitable, Callable, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, Sequence, TypeVar
 
+from services.media.resolver import resolve_cached_media_items
 from utils.download_manager import (
     DownloadMetrics,
     DownloadQueueBusyError,
@@ -76,6 +77,26 @@ async def handle_download_backpressure(
         await on_queue_busy_reply(exc.position)
         return
     raise exc
+
+
+def make_message_backpressure_handler(
+    message: Any,
+    business_id: Optional[int],
+    *,
+    build_rate_limit_text: Callable[[Any], str],
+    build_queue_busy_text: Callable[[int], str],
+    handle_download_error: Callable[..., Awaitable[Any]],
+) -> Callable[[Exception], Awaitable[None]]:
+    async def _handle_backpressure(exc: Exception) -> None:
+        await handle_download_backpressure(
+            exc,
+            business_id=business_id,
+            on_rate_limit_reply=lambda retry_after: message.reply(build_rate_limit_text(retry_after)),
+            on_queue_busy_reply=lambda position: message.reply(build_queue_busy_text(position)),
+            on_business_error=lambda: handle_download_error(message, business_id=business_id),
+        )
+
+    return _handle_backpressure
 
 
 async def run_single_media_flow(
@@ -236,3 +257,45 @@ async def run_media_collection_flow(
         await delete_status_message()
         if cleanup:
             await cleanup()
+
+
+async def run_media_group_flow(
+    *,
+    media_list: Sequence[Any],
+    db_service: Any,
+    kind_getter: Callable[[Any], str],
+    build_cache_key: Callable[[int, Any, str], str],
+    download_item: Callable[[int, Any, str], Awaitable[Any]],
+    metrics_label: str,
+    error_label: str,
+    update_status: Callable[[str], Awaitable[None]],
+    upload_status_text: str,
+    send_entries: Callable[[list[dict[str, Any]]], Awaitable[None]],
+    on_empty: Callable[[], Awaitable[None]],
+    delete_status_message: Callable[[], Awaitable[None]],
+    cleanup_path: Callable[[str], Awaitable[None]],
+    on_after_send: Optional[Callable[[], Awaitable[None]]] = None,
+) -> bool:
+    media_items, downloaded_paths = await resolve_cached_media_items(
+        media_list,
+        db_service=db_service,
+        kind_getter=kind_getter,
+        build_cache_key=build_cache_key,
+        download_item=download_item,
+        metrics_label=metrics_label,
+        error_label=error_label,
+    )
+    if not media_items:
+        await on_empty()
+        return False
+
+    try:
+        await update_status(upload_status_text)
+        await send_entries(media_items)
+        if on_after_send:
+            await on_after_send()
+        return True
+    finally:
+        await delete_status_message()
+        for path in downloaded_paths:
+            await cleanup_path(path)

--- a/services/platforms/__init__.py
+++ b/services/platforms/__init__.py
@@ -1,7 +1,24 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
+from urllib.parse import urlparse, urlunparse
 
-from utils.download_manager import DownloadMetrics
+from utils.download_manager import (
+    DownloadConfig,
+    DownloadError,
+    DownloadMetrics,
+    DownloadQueueBusyError,
+    DownloadRateLimitError,
+    ResilientDownloader,
+)
+
+
+def strip_url_query(url: str) -> str:
+    """Drop the query string and fragment from a URL, keeping the path."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, "", ""))
 
 
 class BasePlatformMediaService(ABC):
@@ -26,3 +43,96 @@ class BasePlatformMediaService(ABC):
         on_retry: Any = None,
     ) -> Optional[DownloadMetrics]:
         """Download media from the resolved URL to OUTPUT_DIR/filename."""
+
+
+class CobaltMediaService:
+    """Concrete shared base for Cobalt-backed platform media services.
+
+    Owns the common downloader configuration, the Cobalt request helper, and
+    the retryable download_media wrapper shared by the Instagram, Pinterest,
+    SoundCloud and Threads services.
+    """
+
+    _COBALT_TIMEOUT_SECONDS = 15
+    _COBALT_ATTEMPTS = 3
+
+    def __init__(
+        self,
+        output_dir: str,
+        *,
+        source: str,
+        retry_async_operation_func: Callable[..., Awaitable[DownloadMetrics | None]],
+        logger: Any,
+        download_error_message: str,
+        cobalt_api_url: Optional[str] = None,
+        cobalt_api_key: Optional[str] = None,
+        fetch_cobalt_data_func: Optional[Callable[..., Awaitable[dict | None]]] = None,
+        download_headers: Optional[dict[str, str]] = None,
+    ) -> None:
+        self._source = source
+        self._downloader = ResilientDownloader(
+            output_dir,
+            config=DownloadConfig(
+                chunk_size=1024 * 1024,
+                multipart_threshold=16 * 1024 * 1024,
+                max_workers=6,
+                retry_backoff=0.8,
+            ),
+            source=source,
+        )
+        self._cobalt_api_url = cobalt_api_url
+        self._cobalt_api_key = cobalt_api_key
+        self._fetch_cobalt_data = fetch_cobalt_data_func
+        self._retry_async_operation = retry_async_operation_func
+        self._download_headers = download_headers
+        self._logger = logger
+        self._download_error_message = download_error_message
+
+    async def _fetch_cobalt_json(self, payload: dict) -> Optional[dict]:
+        return await self._fetch_cobalt_data(
+            self._cobalt_api_url,
+            self._cobalt_api_key,
+            payload,
+            source=self._source,
+            timeout=self._COBALT_TIMEOUT_SECONDS,
+            attempts=self._COBALT_ATTEMPTS,
+        )
+
+    async def download_media(
+        self,
+        url: str,
+        filename: str,
+        *,
+        user_id: Optional[int] = None,
+        chat_id: Optional[int] = None,
+        request_id: Optional[str] = None,
+        size_hint: Optional[int] = None,
+        on_queued=None,
+        on_progress=None,
+        on_retry=None,
+    ) -> Optional[DownloadMetrics]:
+        async def _download_once() -> DownloadMetrics:
+            return await self._downloader.download(
+                url,
+                filename,
+                headers=self._download_headers,
+                user_id=user_id,
+                chat_id=chat_id,
+                request_id=request_id,
+                size_hint=size_hint,
+                on_queued=on_queued,
+                on_progress=on_progress,
+            )
+
+        try:
+            return await self._retry_async_operation(
+                _download_once,
+                attempts=3,
+                retry_on_exception=lambda exc: not isinstance(exc, (DownloadRateLimitError, DownloadQueueBusyError)),
+                on_retry=on_retry,
+            )
+        except (DownloadRateLimitError, DownloadQueueBusyError):
+            raise
+        except DownloadError as exc:
+            self._logger.error(self._download_error_message, url, exc)
+            return None

--- a/services/platforms/instagram_media.py
+++ b/services/platforms/instagram_media.py
@@ -1,28 +1,18 @@
 import hashlib
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional
-from urllib.parse import urlparse, urlunparse
 
 from services.logger import logger as logging
-from utils.cobalt_media import classify_cobalt_media_type
+from services.platforms import CobaltMediaService, strip_url_query
+from utils.cobalt_media import parse_cobalt_media_response
 from utils.download_manager import (
-    DownloadConfig,
-    DownloadError,
+    DownloadError as DownloadError,  # noqa: F401  (re-exported for handlers)
     DownloadMetrics,
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    ResilientDownloader,
 )
 
 logging = logging.bind(service="instagram_media")
 
-
-def strip_instagram_url(url: str) -> str:
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return url
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, "", ""))
+strip_instagram_url = strip_url_query
 
 
 @dataclass
@@ -38,14 +28,6 @@ class InstagramVideo:
     description: str
     author: str
     media_list: list[InstagramMedia]
-
-
-def _extract_instagram_thumb(source: dict) -> Optional[str]:
-    for key in ("thumb", "thumbnail", "poster", "preview", "cover"):
-        value = source.get(key)
-        if isinstance(value, str) and value:
-            return value
-    return None
 
 
 def get_instagram_preview_url(media: Optional[InstagramMedia]) -> Optional[str]:
@@ -96,7 +78,7 @@ def _extract_instagram_post_id(url: str) -> str:
     return ""
 
 
-class InstagramMediaService:
+class InstagramMediaService(CobaltMediaService):
     def __init__(
         self,
         output_dir: str,
@@ -106,17 +88,16 @@ class InstagramMediaService:
         fetch_cobalt_data_func: Callable[..., Awaitable[dict | None]],
         retry_async_operation_func: Callable[..., Awaitable[DownloadMetrics | None]],
     ) -> None:
-        config = DownloadConfig(
-            chunk_size=1024 * 1024,
-            multipart_threshold=16 * 1024 * 1024,
-            max_workers=6,
-            retry_backoff=0.8,
+        super().__init__(
+            output_dir,
+            source="instagram",
+            cobalt_api_url=cobalt_api_url,
+            cobalt_api_key=cobalt_api_key,
+            fetch_cobalt_data_func=fetch_cobalt_data_func,
+            retry_async_operation_func=retry_async_operation_func,
+            logger=logging,
+            download_error_message="Error downloading Instagram media: url=%s error=%s",
         )
-        self._downloader = ResilientDownloader(output_dir, config=config, source="instagram")
-        self._cobalt_api_url = cobalt_api_url
-        self._cobalt_api_key = cobalt_api_key
-        self._fetch_cobalt_data = fetch_cobalt_data_func
-        self._retry_async_operation = retry_async_operation_func
 
     async def fetch_data(self, url: str, audio_only: bool = False) -> Optional[InstagramVideo]:
         payload = {
@@ -126,117 +107,33 @@ class InstagramMediaService:
             "alwaysProxy": True,
             "localProcessing": "disabled",
         }
-        data = await self._fetch_cobalt_data(
-            self._cobalt_api_url,
-            self._cobalt_api_key,
-            payload,
-            source="instagram",
-            timeout=15,
-            attempts=3,
-        )
+        data = await self._fetch_cobalt_json(payload)
         if not data:
             return None
 
-        media_list = []
-        status = data.get("status")
+        parsed = parse_cobalt_media_response(data, audio_only=audio_only, source="instagram")
+        if not parsed:
+            return None
+
+        media_list = [
+            InstagramMedia(url=media_url, type=media_type, thumb=thumb)
+            for media_url, media_type, thumb in parsed.items
+        ]
+
         description = ""
         author = ""
-
-        if not status:
-            if "url" in data:
-                status = "tunnel"
-            elif "picker" in data:
-                status = "picker"
-
-        if status in {"tunnel", "redirect"}:
-            media_url = data.get("url")
+        if parsed.status in {"tunnel", "redirect"}:
             filename = data.get("filename", "")
-            if isinstance(media_url, str) and media_url:
-                media_list.append(
-                    InstagramMedia(
-                        url=media_url,
-                        type=classify_cobalt_media_type(
-                            media_url,
-                            audio_only=audio_only,
-                            filename=filename,
-                        ),
-                        thumb=_extract_instagram_thumb(data),
-                    )
-                )
             if isinstance(filename, str):
                 description = _extract_cobalt_description(data, fallback_url=url)
             author = _extract_cobalt_author(data, filename)
-        elif status == "picker":
-            picker_audio_url = data.get("audio")
-            if audio_only and isinstance(picker_audio_url, str) and picker_audio_url:
-                media_list.append(InstagramMedia(url=picker_audio_url, type="audio"))
-            else:
-                picker_items = data.get("picker") or []
-                for item in picker_items:
-                    if not isinstance(item, dict):
-                        continue
-                    media_url = item.get("url")
-                    if not isinstance(media_url, str) or not media_url:
-                        continue
-                    media_list.append(
-                        InstagramMedia(
-                            url=media_url,
-                            type=classify_cobalt_media_type(
-                                media_url,
-                                audio_only=audio_only,
-                                declared_type=item.get("type"),
-                            ),
-                            thumb=_extract_instagram_thumb(item),
-                        )
-                    )
+        elif parsed.status == "picker":
             description = _extract_cobalt_description(data, fallback_url=url)
             author = _extract_cobalt_author(data, "")
-        elif status == "local-processing":
-            tunnel_urls = data.get("tunnel") or []
+        elif parsed.status == "local-processing":
             output = data.get("output") or {}
-            if not isinstance(tunnel_urls, list) or not tunnel_urls:
-                logging.error("Cobalt local-processing response has no tunnels: payload=%s", data)
-                return None
-            if not audio_only and len(tunnel_urls) > 1:
-                logging.error(
-                    "Unsupported Cobalt local-processing payload for Instagram: type=%s tunnel_count=%s",
-                    data.get("type"),
-                    len(tunnel_urls),
-                )
-                return None
-            for media_url in tunnel_urls:
-                if not isinstance(media_url, str) or not media_url:
-                    continue
-                media_list.append(
-                    InstagramMedia(
-                        url=media_url,
-                        type=classify_cobalt_media_type(
-                            media_url,
-                            audio_only=audio_only,
-                            declared_type=data.get("type"),
-                            filename=output.get("filename") if isinstance(output, dict) else None,
-                            mime_type=output.get("type") if isinstance(output, dict) else None,
-                        ),
-                        thumb=_extract_instagram_thumb(data) or _extract_instagram_thumb(output),
-                    )
-                )
             description = _extract_cobalt_description(data, fallback_url=url)
             author = _extract_cobalt_author(data, output.get("filename", "") if isinstance(output, dict) else "")
-        elif status == "error":
-            error_obj = data.get("error") or {}
-            logging.error(
-                "Cobalt API returned error: code=%s context=%s",
-                error_obj.get("code") if isinstance(error_obj, dict) else None,
-                error_obj.get("context") if isinstance(error_obj, dict) else None,
-            )
-            return None
-        else:
-            logging.error("Unsupported Cobalt response status: status=%s payload=%s", status, data)
-            return None
-
-        if not media_list:
-            logging.error("Cobalt response has no media items: status=%s payload=%s", status, data)
-            return None
 
         post_id = _extract_instagram_post_id(url) or hashlib.blake2s(
             url.encode("utf-8"), digest_size=8
@@ -247,41 +144,3 @@ class InstagramMediaService:
             author=author or "instagram_user",
             media_list=media_list,
         )
-
-    async def download_media(
-        self,
-        url: str,
-        filename: str,
-        *,
-        user_id: Optional[int] = None,
-        chat_id: Optional[int] = None,
-        request_id: Optional[str] = None,
-        size_hint: Optional[int] = None,
-        on_queued=None,
-        on_progress=None,
-        on_retry=None,
-    ) -> Optional[DownloadMetrics]:
-        async def _download_once():
-            return await self._downloader.download(
-                url,
-                filename,
-                user_id=user_id,
-                chat_id=chat_id,
-                request_id=request_id,
-                size_hint=size_hint,
-                on_queued=on_queued,
-                on_progress=on_progress,
-            )
-
-        try:
-            return await self._retry_async_operation(
-                _download_once,
-                attempts=3,
-                retry_on_exception=lambda exc: not isinstance(exc, (DownloadRateLimitError, DownloadQueueBusyError)),
-                on_retry=on_retry,
-            )
-        except (DownloadRateLimitError, DownloadQueueBusyError):
-            raise
-        except DownloadError as exc:
-            logging.error("Error downloading Instagram media: url=%s error=%s", url, exc)
-            return None

--- a/services/platforms/pinterest_media.py
+++ b/services/platforms/pinterest_media.py
@@ -2,28 +2,18 @@ import hashlib
 import json
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional
-from urllib.parse import urlparse, urlunparse
 
 from services.logger import logger as logging
-from utils.cobalt_media import classify_cobalt_media_type
+from services.platforms import CobaltMediaService, strip_url_query
+from utils.cobalt_media import parse_cobalt_media_response
 from utils.download_manager import (
-    DownloadConfig,
-    DownloadError,
+    DownloadError as DownloadError,  # noqa: F401  (re-exported for handlers)
     DownloadMetrics,
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    ResilientDownloader,
 )
 
 logging = logging.bind(service="pinterest_media")
 
-
-def strip_pinterest_url(url: str) -> str:
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return url
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, "", ""))
+strip_pinterest_url = strip_url_query
 
 
 def _derive_description(data: dict) -> str:
@@ -54,14 +44,6 @@ class PinterestPost:
     media_list: list[PinterestMedia]
 
 
-def _extract_pinterest_thumb(source: dict) -> Optional[str]:
-    for key in ("thumb", "thumbnail", "poster", "preview", "cover"):
-        value = source.get(key)
-        if isinstance(value, str) and value:
-            return value
-    return None
-
-
 def get_pinterest_preview_url(media: Optional[PinterestMedia]) -> Optional[str]:
     if not media:
         return None
@@ -71,82 +53,14 @@ def get_pinterest_preview_url(media: Optional[PinterestMedia]) -> Optional[str]:
 
 
 def parse_pinterest_post(data: dict) -> Optional[PinterestPost]:
-    if not isinstance(data, dict):
+    parsed = parse_cobalt_media_response(data, allow_multi_tunnel=True, source="pinterest")
+    if not parsed:
         return None
 
-    status = data.get("status")
-    if status == "error":
-        error_obj = data.get("error") or {}
-        logging.error(
-            "Cobalt Pinterest API error: code=%s context=%s",
-            error_obj.get("code") if isinstance(error_obj, dict) else None,
-            error_obj.get("context") if isinstance(error_obj, dict) else None,
-        )
-        return None
-
-    if not status:
-        if "url" in data:
-            status = "tunnel"
-        elif "picker" in data:
-            status = "picker"
-
-    media_list: list[PinterestMedia] = []
-
-    if status in {"tunnel", "redirect"}:
-        media_url = data.get("url")
-        if isinstance(media_url, str) and media_url:
-            media_list.append(
-                PinterestMedia(
-                    url=media_url,
-                    type=classify_cobalt_media_type(
-                        media_url,
-                        filename=data.get("filename"),
-                    ),
-                    thumb=_extract_pinterest_thumb(data),
-                )
-            )
-    elif status == "picker":
-        for item in data.get("picker") or []:
-            if not isinstance(item, dict):
-                continue
-            media_url = item.get("url")
-            if not isinstance(media_url, str) or not media_url:
-                continue
-            media_list.append(
-                PinterestMedia(
-                    url=media_url,
-                    type=classify_cobalt_media_type(
-                        media_url,
-                        declared_type=item.get("type"),
-                    ),
-                    thumb=_extract_pinterest_thumb(item),
-                )
-            )
-    elif status == "local-processing":
-        tunnels = data.get("tunnel") or []
-        output = data.get("output") if isinstance(data.get("output"), dict) else {}
-        for media_url in tunnels:
-            if not isinstance(media_url, str) or not media_url:
-                continue
-            media_list.append(
-                PinterestMedia(
-                    url=media_url,
-                    type=classify_cobalt_media_type(
-                        media_url,
-                        declared_type=data.get("type"),
-                        filename=output.get("filename"),
-                        mime_type=output.get("type"),
-                    ),
-                    thumb=_extract_pinterest_thumb(data) or _extract_pinterest_thumb(output),
-                )
-            )
-    else:
-        logging.error("Unsupported Cobalt Pinterest status: status=%s payload=%s", status, data)
-        return None
-
-    if not media_list:
-        logging.error("Cobalt Pinterest response has no media items: payload=%s", data)
-        return None
+    media_list = [
+        PinterestMedia(url=media_url, type=media_type, thumb=thumb)
+        for media_url, media_type, thumb in parsed.items
+    ]
 
     return PinterestPost(
         id=hashlib.blake2s(
@@ -158,7 +72,7 @@ def parse_pinterest_post(data: dict) -> Optional[PinterestPost]:
     )
 
 
-class PinterestMediaService:
+class PinterestMediaService(CobaltMediaService):
     def __init__(
         self,
         output_dir: str,
@@ -168,17 +82,16 @@ class PinterestMediaService:
         fetch_cobalt_data_func: Callable[..., Awaitable[dict | None]],
         retry_async_operation_func: Callable[..., Awaitable[DownloadMetrics | None]],
     ) -> None:
-        config = DownloadConfig(
-            chunk_size=1024 * 1024,
-            multipart_threshold=16 * 1024 * 1024,
-            max_workers=6,
-            retry_backoff=0.8,
+        super().__init__(
+            output_dir,
+            source="pinterest",
+            cobalt_api_url=cobalt_api_url,
+            cobalt_api_key=cobalt_api_key,
+            fetch_cobalt_data_func=fetch_cobalt_data_func,
+            retry_async_operation_func=retry_async_operation_func,
+            logger=logging,
+            download_error_message="Error downloading Pinterest media: url=%s error=%s",
         )
-        self._downloader = ResilientDownloader(output_dir, config=config, source="pinterest")
-        self._cobalt_api_url = cobalt_api_url
-        self._cobalt_api_key = cobalt_api_key
-        self._fetch_cobalt_data = fetch_cobalt_data_func
-        self._retry_async_operation = retry_async_operation_func
 
     async def fetch_post(self, url: str) -> Optional[PinterestPost]:
         payload = {
@@ -188,52 +101,7 @@ class PinterestMediaService:
             "alwaysProxy": True,
             "localProcessing": "disabled",
         }
-        data = await self._fetch_cobalt_data(
-            self._cobalt_api_url,
-            self._cobalt_api_key,
-            payload,
-            source="pinterest",
-            timeout=15,
-            attempts=3,
-        )
+        data = await self._fetch_cobalt_json(payload)
         if not data:
             return None
         return parse_pinterest_post(data)
-
-    async def download_media(
-        self,
-        url: str,
-        filename: str,
-        *,
-        user_id: Optional[int] = None,
-        chat_id: Optional[int] = None,
-        request_id: Optional[str] = None,
-        size_hint: Optional[int] = None,
-        on_queued=None,
-        on_progress=None,
-        on_retry=None,
-    ) -> Optional[DownloadMetrics]:
-        async def _download_once():
-            return await self._downloader.download(
-                url,
-                filename,
-                user_id=user_id,
-                chat_id=chat_id,
-                request_id=request_id,
-                size_hint=size_hint,
-                on_queued=on_queued,
-                on_progress=on_progress,
-            )
-
-        try:
-            return await self._retry_async_operation(
-                _download_once,
-                attempts=3,
-                retry_on_exception=lambda exc: not isinstance(exc, (DownloadRateLimitError, DownloadQueueBusyError)),
-                on_retry=on_retry,
-            )
-        except (DownloadRateLimitError, DownloadQueueBusyError):
-            raise
-        except DownloadError as exc:
-            logging.error("Error downloading Pinterest media: url=%s error=%s", url, exc)
-            return None

--- a/services/platforms/soundcloud_media.py
+++ b/services/platforms/soundcloud_media.py
@@ -1,17 +1,13 @@
 import hashlib
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional
-from urllib.parse import urlparse, urlunparse
 
 from services.logger import logger as logging
 from services.media.artist_names import normalize_artist_names
+from services.platforms import CobaltMediaService, strip_url_query
 from utils.download_manager import (
-    DownloadConfig,
-    DownloadError,
+    DownloadError as DownloadError,  # noqa: F401  (re-exported for handlers)
     DownloadMetrics,
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    ResilientDownloader,
 )
 
 logging = logging.bind(service="soundcloud_media")
@@ -28,12 +24,7 @@ class SoundCloudTrack:
     duration_seconds: int = 0
 
 
-def strip_soundcloud_url(url: str) -> str:
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return url
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, "", ""))
+strip_soundcloud_url = strip_url_query
 
 
 def _looks_like_image_url(url: str) -> bool:
@@ -161,7 +152,7 @@ def parse_soundcloud_track(data: dict, source_url: str) -> Optional[SoundCloudTr
     )
 
 
-class SoundCloudMediaService:
+class SoundCloudMediaService(CobaltMediaService):
     def __init__(
         self,
         output_dir: str,
@@ -171,17 +162,16 @@ class SoundCloudMediaService:
         fetch_cobalt_data_func: Callable[..., Awaitable[dict | None]],
         retry_async_operation_func: Callable[..., Awaitable[DownloadMetrics | None]],
     ) -> None:
-        config = DownloadConfig(
-            chunk_size=1024 * 1024,
-            multipart_threshold=16 * 1024 * 1024,
-            max_workers=6,
-            retry_backoff=0.8,
+        super().__init__(
+            output_dir,
+            source="soundcloud",
+            cobalt_api_url=cobalt_api_url,
+            cobalt_api_key=cobalt_api_key,
+            fetch_cobalt_data_func=fetch_cobalt_data_func,
+            retry_async_operation_func=retry_async_operation_func,
+            logger=logging,
+            download_error_message="Error downloading SoundCloud media: url=%s error=%s",
         )
-        self._downloader = ResilientDownloader(output_dir, config=config, source="soundcloud")
-        self._cobalt_api_url = cobalt_api_url
-        self._cobalt_api_key = cobalt_api_key
-        self._fetch_cobalt_data = fetch_cobalt_data_func
-        self._retry_async_operation = retry_async_operation_func
 
     async def fetch_track(self, url: str) -> Optional[SoundCloudTrack]:
         payload = {
@@ -193,52 +183,7 @@ class SoundCloudMediaService:
             "localProcessing": "preferred",
             "disableMetadata": False,
         }
-        data = await self._fetch_cobalt_data(
-            self._cobalt_api_url,
-            self._cobalt_api_key,
-            payload,
-            source="soundcloud",
-            timeout=15,
-            attempts=3,
-        )
+        data = await self._fetch_cobalt_json(payload)
         if not data:
             return None
         return parse_soundcloud_track(data, url)
-
-    async def download_media(
-        self,
-        url: str,
-        filename: str,
-        *,
-        user_id: Optional[int] = None,
-        chat_id: Optional[int] = None,
-        request_id: Optional[str] = None,
-        size_hint: Optional[int] = None,
-        on_queued=None,
-        on_progress=None,
-        on_retry=None,
-    ) -> Optional[DownloadMetrics]:
-        async def _download_once():
-            return await self._downloader.download(
-                url,
-                filename,
-                user_id=user_id,
-                chat_id=chat_id,
-                request_id=request_id,
-                size_hint=size_hint,
-                on_queued=on_queued,
-                on_progress=on_progress,
-            )
-
-        try:
-            return await self._retry_async_operation(
-                _download_once,
-                attempts=3,
-                retry_on_exception=lambda exc: not isinstance(exc, (DownloadRateLimitError, DownloadQueueBusyError)),
-                on_retry=on_retry,
-            )
-        except (DownloadRateLimitError, DownloadQueueBusyError):
-            raise
-        except DownloadError as exc:
-            logging.error("Error downloading SoundCloud media: url=%s error=%s", url, exc)
-            return None

--- a/services/platforms/threads_media.py
+++ b/services/platforms/threads_media.py
@@ -4,17 +4,14 @@ import json
 import re
 from dataclasses import dataclass
 from html.parser import HTMLParser
-from typing import Any, Awaitable, Callable, Iterator, Optional
+from typing import Any, Awaitable, Callable, Iterator
 from urllib.parse import urlparse
 
 from services.logger import logger as logging
+from services.platforms import CobaltMediaService
 from utils.download_manager import (
-    DownloadConfig,
-    DownloadError,
+    DownloadError as DownloadError,  # noqa: F401  (re-exported for handlers)
     DownloadMetrics,
-    DownloadQueueBusyError,
-    DownloadRateLimitError,
-    ResilientDownloader,
 )
 from utils.http_client import get_http_session
 
@@ -100,13 +97,15 @@ class _JsonScriptParser(HTMLParser):
             self._body = None
 
 
-def _iter_json_blobs(page: str) -> Iterator[dict[str, Any]]:
+def _iter_json_blobs(page: str, *, contains: str | None = None) -> Iterator[dict[str, Any]]:
     parser = _JsonScriptParser()
     parser.feed(page)
     for attrs, body in parser.scripts:
         if attrs.get("type") != "application/json" or "data-sjs" not in attrs:
             continue
         if not body.lstrip().startswith("{"):
+            continue
+        if contains is not None and contains not in body:
             continue
         try:
             payload = json.loads(body)
@@ -128,13 +127,14 @@ def _walk_json(value: Any) -> Iterator[dict[str, Any]]:
 
 def _find_post(page: str, post_code: str) -> dict[str, Any] | None:
     needle = f'"code":"{post_code}"'
-    for payload in _iter_json_blobs(page):
-        serialized = json.dumps(payload, separators=(",", ":"))
-        if needle not in serialized:
-            continue
-        for node in _walk_json(payload):
-            if node.get("code") == post_code:
-                return node
+    # Threads blobs are minified, so the needle usually matches the raw script
+    # text; pre-filter on it to avoid parsing unrelated blobs, then fall back
+    # to parsing every blob in case the raw-text match missed.
+    for contains in (needle, None):
+        for payload in _iter_json_blobs(page, contains=contains):
+            for node in _walk_json(payload):
+                if node.get("code") == post_code:
+                    return node
     return None
 
 
@@ -233,7 +233,7 @@ async def fetch_threads_post_html(url: str) -> str:
         return await response.text()
 
 
-class ThreadsMediaService:
+class ThreadsMediaService(CobaltMediaService):
     def __init__(
         self,
         output_dir: str,
@@ -241,18 +241,15 @@ class ThreadsMediaService:
         fetch_page_func: Callable[[str], Awaitable[str]] = fetch_threads_post_html,
         retry_async_operation_func: Callable[..., Awaitable[DownloadMetrics | None]],
     ) -> None:
-        self._fetch_page = fetch_page_func
-        self._retry_async_operation = retry_async_operation_func
-        self._downloader = ResilientDownloader(
+        super().__init__(
             output_dir,
-            config=DownloadConfig(
-                chunk_size=1024 * 1024,
-                multipart_threshold=16 * 1024 * 1024,
-                max_workers=6,
-                retry_backoff=0.8,
-            ),
             source="threads",
+            retry_async_operation_func=retry_async_operation_func,
+            logger=logging,
+            download_error_message="Threads media download failed: url=%s error=%s",
+            download_headers=THREADS_MEDIA_HEADERS,
         )
+        self._fetch_page = fetch_page_func
 
     async def fetch_post(self, url: str) -> ThreadsPost | None:
         source_url = strip_threads_url(url)
@@ -270,42 +267,3 @@ class ThreadsMediaService:
         if not post:
             logging.warning("Threads post has no extractable content: post=%s", post_code)
         return post
-
-    async def download_media(
-        self,
-        url: str,
-        filename: str,
-        *,
-        user_id: Optional[int] = None,
-        chat_id: Optional[int] = None,
-        request_id: Optional[str] = None,
-        size_hint: Optional[int] = None,
-        on_queued=None,
-        on_progress=None,
-        on_retry=None,
-    ) -> DownloadMetrics | None:
-        async def _download_once() -> DownloadMetrics:
-            return await self._downloader.download(
-                url,
-                filename,
-                headers=THREADS_MEDIA_HEADERS,
-                user_id=user_id,
-                chat_id=chat_id,
-                request_id=request_id,
-                size_hint=size_hint,
-                on_queued=on_queued,
-                on_progress=on_progress,
-            )
-
-        try:
-            return await self._retry_async_operation(
-                _download_once,
-                attempts=3,
-                retry_on_exception=lambda exc: not isinstance(exc, (DownloadRateLimitError, DownloadQueueBusyError)),
-                on_retry=on_retry,
-            )
-        except (DownloadRateLimitError, DownloadQueueBusyError):
-            raise
-        except DownloadError as exc:
-            logging.error("Threads media download failed: url=%s error=%s", url, exc)
-            return None

--- a/services/platforms/tiktok_download_mixin.py
+++ b/services/platforms/tiktok_download_mixin.py
@@ -6,6 +6,11 @@ from typing import Any, Callable, Optional
 from services.logger import logger as logging
 from services.download.queue import QueueBackpressureError, QueueRateLimitError, get_download_queue
 from services.platforms.tiktok_common import _safe_int, get_video_id_from_url
+from services.platforms.ytdlp_helpers import (
+    mp3_extract_postprocessors,
+    resolve_downloaded_path,
+    run_ytdlp_download,
+)
 from utils.download_manager import (
     DownloadError,
     DownloadMetrics,
@@ -134,8 +139,7 @@ class TikTokDownloadMixin:
         return _hook
 
     def _run_ytdlp_download(self, url: str, ydl_opts: dict[str, Any]) -> None:
-        with self._youtube_dl_factory(ydl_opts) as ydl:
-            ydl.download([url])
+        run_ytdlp_download(self._youtube_dl_factory, url, ydl_opts)
 
     @staticmethod
     def _cleanup_paths(*paths: str) -> None:
@@ -154,37 +158,22 @@ class TikTokDownloadMixin:
                 except OSError:
                     logging.debug("Failed to clean up TikTok yt-dlp artifact: path=%s", normalized)
 
-    @staticmethod
-    def _resolve_downloaded_path(expected_path: str) -> str:
-        if os.path.exists(expected_path):
-            return expected_path
-        stem, ext = os.path.splitext(expected_path)
-        matches = sorted(glob.glob(f"{stem}*{ext}") + glob.glob(f"{stem}.*"))
-        for match in matches:
-            if os.path.isfile(match):
-                return match
-        raise DownloadError(f"yt-dlp output file missing: {expected_path}")
+    _resolve_downloaded_path = staticmethod(resolve_downloaded_path)
 
-    def _download_video_with_ytdlp_sync(
+    def _download_media_with_ytdlp_sync(
         self,
         *,
         source_url: str,
         output_path: str,
+        outtmpl: str,
+        ydl_overrides: dict[str, Any],
         progress_callback=None,
     ) -> DownloadMetrics:
         started_at = self._monotonic()
         ydl_opts = {
             **self._build_ytdlp_download_options(),
-            "format": (
-                "best[ext=mp4][acodec!=none][vcodec!=none]/"
-                "best[acodec!=none][vcodec!=none]/"
-                "best*[ext=mp4][acodec!=none][vcodec!=none]/"
-                "best*[acodec!=none][vcodec!=none]/"
-                "bestvideo[ext=mp4]+bestaudio[ext=m4a]/"
-                "bestvideo+bestaudio/best"
-            ),
-            "outtmpl": output_path,
-            "merge_output_format": "mp4",
+            **ydl_overrides,
+            "outtmpl": outtmpl,
             "progress_hooks": [self._build_progress_hook(progress_callback, started_at)],
         }
         try:
@@ -212,6 +201,31 @@ class TikTokDownloadMixin:
             self._cleanup_paths(output_path, f"{os.path.splitext(output_path)[0]}.*")
             raise DownloadError(str(exc)) from exc
 
+    def _download_video_with_ytdlp_sync(
+        self,
+        *,
+        source_url: str,
+        output_path: str,
+        progress_callback=None,
+    ) -> DownloadMetrics:
+        return self._download_media_with_ytdlp_sync(
+            source_url=source_url,
+            output_path=output_path,
+            outtmpl=output_path,
+            ydl_overrides={
+                "format": (
+                    "best[ext=mp4][acodec!=none][vcodec!=none]/"
+                    "best[acodec!=none][vcodec!=none]/"
+                    "best*[ext=mp4][acodec!=none][vcodec!=none]/"
+                    "best*[acodec!=none][vcodec!=none]/"
+                    "bestvideo[ext=mp4]+bestaudio[ext=m4a]/"
+                    "bestvideo+bestaudio/best"
+                ),
+                "merge_output_format": "mp4",
+            },
+            progress_callback=progress_callback,
+        )
+
     def _download_audio_with_ytdlp_sync(
         self,
         *,
@@ -219,45 +233,18 @@ class TikTokDownloadMixin:
         output_path: str,
         progress_callback=None,
     ) -> DownloadMetrics:
-        started_at = self._monotonic()
         base_path, _ = os.path.splitext(output_path)
-        out_template = f"{base_path}.%(ext)s"
-        ydl_opts = {
-            **self._build_ytdlp_download_options(),
-            "format": "bestaudio/best",
-            "outtmpl": out_template,
-            "postprocessors": [{
-                "key": "FFmpegExtractAudio",
-                "preferredcodec": "mp3",
-                "preferredquality": "192",
-            }],
-            "merge_output_format": "mp3",
-            "progress_hooks": [self._build_progress_hook(progress_callback, started_at)],
-        }
-        try:
-            self._run_ytdlp_download(source_url, ydl_opts)
-            resolved_path = self._resolve_downloaded_path(output_path)
-            size = os.path.getsize(resolved_path)
-            self._notify_progress(
-                progress_callback,
-                downloaded_bytes=size,
-                total_bytes=size,
-                started_at=started_at,
-                speed_bps=0.0,
-                eta_seconds=0.0,
-                done=True,
-            )
-            return DownloadMetrics(
-                url=source_url,
-                path=resolved_path,
-                size=size,
-                elapsed=self._monotonic() - started_at,
-                used_multipart=False,
-                resumed=False,
-            )
-        except Exception as exc:
-            self._cleanup_paths(output_path, f"{base_path}.*")
-            raise DownloadError(str(exc)) from exc
+        return self._download_media_with_ytdlp_sync(
+            source_url=source_url,
+            output_path=output_path,
+            outtmpl=f"{base_path}.%(ext)s",
+            ydl_overrides={
+                "format": "bestaudio/best",
+                "postprocessors": mp3_extract_postprocessors(),
+                "merge_output_format": "mp3",
+            },
+            progress_callback=progress_callback,
+        )
 
     def _build_direct_download_headers(self, source_url: str, source_data: dict[str, Any], key: str) -> dict[str, str]:
         headers = {

--- a/services/platforms/tiktok_metadata_mixin.py
+++ b/services/platforms/tiktok_metadata_mixin.py
@@ -39,7 +39,18 @@ class TikTokMetadataMixin:
         video_id = get_video_id_from_url(video_url)
         with self._youtube_dl_factory(self._build_ytdlp_options()) as ydl:
             extractor = TikTokIE(ydl)
-            detail, status = extractor._extract_web_data_and_status(video_url, video_id, fatal=False)
+            try:
+                # Private yt-dlp extractor internals; a yt-dlp bump can change
+                # or remove this method, so degrade to "post unavailable"
+                # instead of crashing the fallback path.
+                detail, status = extractor._extract_web_data_and_status(video_url, video_id, fatal=False)
+            except (AttributeError, TypeError) as exc:
+                logging.error(
+                    "TikTok yt-dlp extractor internals incompatible: url=%s error=%s",
+                    video_url,
+                    exc,
+                )
+                return {}, 1
         if not isinstance(detail, dict):
             detail = {}
         return detail, status

--- a/services/platforms/tiktok_profile_mixin.py
+++ b/services/platforms/tiktok_profile_mixin.py
@@ -7,9 +7,12 @@ logging = logging.bind(service="tiktok_media")
 
 
 class TikTokProfileMixin:
+    USER_LOOKUP_MAX_RETRIES = 10
+    USER_LOOKUP_RETRY_DELAY_SECONDS = 1.5
+
     async def fetch_user_info(self, username: str) -> TikTokUser | None:
-        max_retries = 10
-        retry_delay = 1.5
+        max_retries = self.USER_LOOKUP_MAX_RETRIES
+        retry_delay = self.USER_LOOKUP_RETRY_DELAY_SECONDS
         exist_data: dict | None = None
         session = await self._get_http_session()
         headers = {"User-Agent": self._get_user_agent()}
@@ -25,6 +28,11 @@ class TikTokProfileMixin:
                     sec_user_id = exist_data.get("sec_uid") if isinstance(exist_data, dict) else None
                     if sec_user_id:
                         break
+                    logging.warning(
+                        "TikTok user lookup missing sec_uid: attempt=%s username=%s",
+                        attempt + 1,
+                        username,
+                    )
                 except Exception as exc:
                     logging.warning(
                         "TikTok user lookup retry failed: attempt=%s username=%s error=%s",
@@ -32,7 +40,9 @@ class TikTokProfileMixin:
                         username,
                         exc,
                     )
-                    await asyncio.sleep(retry_delay)
+                # Sleep on every failed iteration (missing sec_uid included),
+                # not only when the request itself raised.
+                await asyncio.sleep(retry_delay)
             else:
                 logging.error("Failed to get TikTok user data after %s attempts: username=%s", max_retries, username)
                 return None

--- a/services/platforms/tiktok_url_mixin.py
+++ b/services/platforms/tiktok_url_mixin.py
@@ -15,20 +15,43 @@ logging = logging.bind(service="tiktok_media")
 
 
 class TikTokUrlResolverMixin:
+    def _get_expanded_tiktok_url_inflight(self) -> dict[str, "asyncio.Future[str]"]:
+        inflight = getattr(self, "_expanded_tiktok_url_inflight", None)
+        if inflight is None:
+            inflight = {}
+            self._expanded_tiktok_url_inflight = inflight
+        return inflight
+
     async def _expand_tiktok_url_cached_async(self, url: str) -> str:
         cached = self._expanded_tiktok_url_cache.get(url)
         if cached is not None:
             self._expanded_tiktok_url_cache.move_to_end(url)
             return cached
 
-        session = await self._get_http_session()
-        headers = {"User-Agent": self._get_user_agent()}
+        # Hold the lock only to check the cache and claim a per-URL in-flight
+        # future; the HEAD request itself runs outside the lock so different
+        # URLs expand concurrently while duplicate URLs coalesce.
+        inflight = self._get_expanded_tiktok_url_inflight()
         async with self._expanded_tiktok_url_lock:
             cached = self._expanded_tiktok_url_cache.get(url)
             if cached is not None:
                 self._expanded_tiktok_url_cache.move_to_end(url)
                 return cached
+            existing = inflight.get(url)
+            if existing is not None and not existing.done():
+                future = existing
+                is_leader = False
+            else:
+                future = asyncio.get_running_loop().create_future()
+                inflight[url] = future
+                is_leader = True
 
+        if not is_leader:
+            return await asyncio.shield(future)
+
+        try:
+            session = await self._get_http_session()
+            headers = {"User-Agent": self._get_user_agent()}
             async with session.head(
                 url,
                 allow_redirects=True,
@@ -37,11 +60,26 @@ class TikTokUrlResolverMixin:
             ) as response:
                 expanded = str(response.url) or url
 
-            self._expanded_tiktok_url_cache[url] = expanded
-            self._expanded_tiktok_url_cache.move_to_end(url)
-            if len(self._expanded_tiktok_url_cache) > URL_EXPAND_CACHE_MAXSIZE:
-                self._expanded_tiktok_url_cache.popitem(last=False)
+            async with self._expanded_tiktok_url_lock:
+                self._expanded_tiktok_url_cache[url] = expanded
+                self._expanded_tiktok_url_cache.move_to_end(url)
+                if len(self._expanded_tiktok_url_cache) > URL_EXPAND_CACHE_MAXSIZE:
+                    self._expanded_tiktok_url_cache.popitem(last=False)
+            if not future.done():
+                future.set_result(expanded)
             return expanded
+        except Exception as exc:
+            if not future.done():
+                future.set_exception(exc)
+                # Mark the exception as retrieved so an abandoned future does
+                # not emit "exception was never retrieved" warnings.
+                future.exception()
+            raise
+        finally:
+            if inflight.get(url) is future:
+                inflight.pop(url, None)
+            if not future.done():
+                future.cancel()
 
     async def process_tiktok_url_async(self, text: str) -> str:
         def extract_tiktok_url(input_text: str) -> str:

--- a/services/platforms/twitter_media.py
+++ b/services/platforms/twitter_media.py
@@ -168,13 +168,15 @@ async def collect_media_entries(
     user_id: Optional[int] = None,
     chat_id: Optional[int] = None,
     request_id: Optional[str] = None,
+    download_dir_name: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     entries: list[dict[str, Any] | None] = []
     download_tasks = []
-    media_meta: list[tuple[int, str, str, str, str]] = []
+    media_meta: list[tuple[int, int, str, str, str, str]] = []
     media_items = extract_twitter_media_items(tweet_media)
     total_items = len(media_items)
     post_url = tweet_media.get("tweetURL") or f"https://x.com/i/status/{tweet_id}"
+    dir_name = download_dir_name or str(tweet_id)
 
     for index, media in enumerate(media_items):
         media_url = media.get("url")
@@ -197,8 +199,9 @@ async def collect_media_entries(
             )
             continue
 
-        file_name = os.path.join(str(tweet_id), os.path.basename(urlsplit(media_url).path))
+        file_name = os.path.join(dir_name, os.path.basename(urlsplit(media_url).path))
         entries.append(None)
+        slot = len(entries) - 1
         logging.debug(
             "Queueing tweet media download: tweet_id=%s type=%s url=%s",
             tweet_id,
@@ -216,13 +219,13 @@ async def collect_media_entries(
                 max_size_bytes=max_file_size,
             )
         )
-        media_meta.append((index, media_kind, file_name, media_url, cache_key))
+        media_meta.append((slot, index, media_kind, file_name, media_url, cache_key))
 
     if not download_tasks:
         return [entry for entry in entries if entry is not None]
 
     results = await asyncio.gather(*download_tasks, return_exceptions=True)
-    for (index, media_kind, file_path, media_url, cache_key), result in zip(media_meta, results):
+    for (slot, index, media_kind, file_path, media_url, cache_key), result in zip(media_meta, results):
         if isinstance(result, (DownloadRateLimitError, DownloadQueueBusyError, DownloadTooLargeError)):
             raise result
         if isinstance(result, Exception):
@@ -249,7 +252,7 @@ async def collect_media_entries(
                 resumed=isinstance(result, DownloadMetrics) and result.resumed,
             ),
         )
-        entries[index] = {
+        entries[slot] = {
             "index": index,
             "kind": media_kind,
             "cache_key": cache_key,
@@ -272,6 +275,7 @@ async def collect_media_files(
     user_id: Optional[int] = None,
     chat_id: Optional[int] = None,
     request_id: Optional[str] = None,
+    download_dir_name: Optional[str] = None,
 ) -> tuple[list[str], list[str]]:
     entries = await collect_media_entries(
         tweet_id,
@@ -283,6 +287,7 @@ async def collect_media_files(
         user_id=user_id,
         chat_id=chat_id,
         request_id=request_id,
+        download_dir_name=download_dir_name,
     )
     photos = [str(entry["path"]) for entry in entries if entry["kind"] == "photo" and entry["path"]]
     videos = [str(entry["path"]) for entry in entries if entry["kind"] == "video" and entry["path"]]

--- a/services/platforms/youtube_media.py
+++ b/services/platforms/youtube_media.py
@@ -7,8 +7,12 @@ from typing import Any, Awaitable, Callable, Optional
 
 from services.logger import logger as logging
 from services.media.artist_names import normalize_artist_names
+from services.platforms.ytdlp_helpers import (
+    mp3_extract_postprocessors,
+    resolve_downloaded_path,
+    run_ytdlp_download,
+)
 from utils.download_manager import (
-    DownloadError,
     DownloadConfig,
     DownloadMetrics,
     DownloadQueueBusyError,
@@ -238,19 +242,9 @@ class YouTubeMediaService:
         )
 
     def _run_ytdlp_download(self, url: str, ydl_opts: dict[str, Any]) -> None:
-        with self._youtube_dl_factory(ydl_opts) as ydl:
-            ydl.download([url])
+        run_ytdlp_download(self._youtube_dl_factory, url, ydl_opts)
 
-    @staticmethod
-    def _resolve_downloaded_path(expected_path: str) -> str:
-        if os.path.exists(expected_path):
-            return expected_path
-        stem, ext = os.path.splitext(expected_path)
-        matches = sorted(glob.glob(f"{stem}*{ext}") + glob.glob(f"{stem}.*"))
-        for match in matches:
-            if os.path.isfile(match):
-                return match
-        raise DownloadError(f"yt-dlp output file missing: {expected_path}")
+    _resolve_downloaded_path = staticmethod(resolve_downloaded_path)
 
     def get_youtube_video(self, url: str) -> Optional[dict[str, Any]]:
         try:
@@ -417,11 +411,7 @@ class YouTubeMediaService:
         ydl_opts = build_ytdlp_youtube_options(
             format="bestaudio[ext=m4a]/bestaudio/best",
             outtmpl=out_template,
-            postprocessors=[{
-                "key": "FFmpegExtractAudio",
-                "preferredcodec": "mp3",
-                "preferredquality": "192",
-            }],
+            postprocessors=mp3_extract_postprocessors(),
             merge_output_format="mp3",
         )
         if max_filesize is not None:

--- a/services/platforms/ytdlp_helpers.py
+++ b/services/platforms/ytdlp_helpers.py
@@ -1,0 +1,35 @@
+"""Shared yt-dlp download scaffolding used by the TikTok and YouTube services."""
+
+import glob
+import os
+from typing import Any, Callable
+
+from utils.download_manager import DownloadError
+
+
+def run_ytdlp_download(
+    youtube_dl_factory: Callable[[dict[str, Any]], Any],
+    url: str,
+    ydl_opts: dict[str, Any],
+) -> None:
+    with youtube_dl_factory(ydl_opts) as ydl:
+        ydl.download([url])
+
+
+def resolve_downloaded_path(expected_path: str) -> str:
+    if os.path.exists(expected_path):
+        return expected_path
+    stem, ext = os.path.splitext(expected_path)
+    matches = sorted(glob.glob(f"{stem}*{ext}") + glob.glob(f"{stem}.*"))
+    for match in matches:
+        if os.path.isfile(match):
+            return match
+    raise DownloadError(f"yt-dlp output file missing: {expected_path}")
+
+
+def mp3_extract_postprocessors() -> list[dict[str, str]]:
+    return [{
+        "key": "FFmpegExtractAudio",
+        "preferredcodec": "mp3",
+        "preferredquality": "192",
+    }]

--- a/services/runtime/state_store.py
+++ b/services/runtime/state_store.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-import copy
+import asyncio
+import atexit
 import json
 from pathlib import Path
 from threading import RLock
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 
 _STATE_FILE = Path(__file__).resolve().parents[2] / ".runtime_state.json"
 _STATE_LOCK = RLock()
+_state: dict[str, Any] = {}
+_state_path: Optional[Path] = None
+_state_dirty = False
+_flush_task: Optional[asyncio.Task] = None
 
 
 def _load_state_unlocked() -> dict[str, Any]:
@@ -19,6 +24,15 @@ def _load_state_unlocked() -> dict[str, Any]:
         return json.loads(_STATE_FILE.read_text(encoding="utf-8"))
     except Exception:
         return {}
+
+
+def _ensure_state_cached_unlocked() -> dict[str, Any]:
+    global _state, _state_path, _state_dirty
+    if _state_path != _STATE_FILE:
+        _state = _load_state_unlocked()
+        _state_path = _STATE_FILE
+        _state_dirty = False
+    return _state
 
 
 def _write_state_unlocked(state: dict[str, Any]) -> None:
@@ -36,20 +50,60 @@ def _write_state_unlocked(state: dict[str, Any]) -> None:
     temp_path.replace(_STATE_FILE)
 
 
+def _flush_state() -> None:
+    global _state_dirty
+    with _STATE_LOCK:
+        if not _state_dirty:
+            return
+        _state_dirty = False
+        if _state_path != _STATE_FILE:
+            return
+        _write_state_unlocked(_state)
+
+
+async def _flush_state_async() -> None:
+    global _flush_task
+    try:
+        while True:
+            await asyncio.to_thread(_flush_state)
+            with _STATE_LOCK:
+                if not _state_dirty:
+                    return
+    finally:
+        _flush_task = None
+
+
+def _schedule_flush() -> None:
+    global _flush_task
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _flush_state()
+        return
+
+    if _flush_task is None or _flush_task.done():
+        _flush_task = loop.create_task(_flush_state_async())
+
+
 def load_bucket(name: str, default_factory: Callable[[], Any]) -> Any:
     with _STATE_LOCK:
-        state = _load_state_unlocked()
+        state = _ensure_state_cached_unlocked()
         value = state.get(name)
         if value is None:
             return default_factory()
-        return copy.deepcopy(value)
+        return value
 
 
 def save_bucket(name: str, value: Any) -> None:
+    global _state_dirty
     with _STATE_LOCK:
-        state = _load_state_unlocked()
+        state = _ensure_state_cached_unlocked()
         if value:
-            state[name] = copy.deepcopy(value)
+            state[name] = value
         else:
             state.pop(name, None)
-        _write_state_unlocked(state)
+        _state_dirty = True
+    _schedule_flush()
+
+
+atexit.register(_flush_state)

--- a/services/storage/analytics_repository.py
+++ b/services/storage/analytics_repository.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 
@@ -9,7 +9,7 @@ from services.storage.models import AnalyticsEvent, NON_DOWNLOAD_ACTIONS, StatsS
 class AnalyticsRepositoryMixin:
     @staticmethod
     def _stats_period_start(period: str) -> datetime:
-        start_date = datetime.now()
+        start_date = datetime.now(timezone.utc)
         if period == "Week":
             start_date -= timedelta(weeks=1)
         elif period == "Month":

--- a/services/storage/models.py
+++ b/services/storage/models.py
@@ -81,9 +81,7 @@ class User(Base):
 class AnalyticsEvent(Base):
     __tablename__ = "analytics_events"
     __table_args__ = (
-        Index("ix_analytics_events_created_at", "created_at"),
         Index("ix_analytics_events_action_name_created_at", "action_name", "created_at"),
-        Index("ix_analytics_events_action_name", "action_name"),
         Index("ix_analytics_events_created_action", "created_at", "action_name"),
     )
 

--- a/services/storage/user_repository.py
+++ b/services/storage/user_repository.py
@@ -13,19 +13,10 @@ logging = logging.bind(service="db_users")
 
 
 class UserRepositoryMixin:
-    async def add_user(self, user_id: int, user_name: str | None, user_username: str | None, chat_type: str | None, language: str | None, status: str | None) -> None:
-        async with self.SessionLocal() as session:
-            async with session.begin():
-                user = User(
-                    user_id=user_id,
-                    user_name=user_name,
-                    user_username=user_username,
-                    chat_type=chat_type,
-                    language=language,
-                    status=status,
-                )
-                session.add(user)
-        self._status_cache[int(user_id)] = (time.monotonic(), status)
+    def _insert(self, model):
+        if self._dialect_name == "postgresql":
+            return pg_insert(model)
+        return sqlite_insert(model)
 
     async def upsert_chat(self, user_id: int, user_name: str | None, user_username: str | None, chat_type: str | None, language: str | None = None, status: str = "active", referred_by: int | None = None, source: str | None = None) -> None:
         values = {
@@ -41,36 +32,12 @@ class UserRepositoryMixin:
             values["source"] = source
         async with self.SessionLocal() as session:
             async with session.begin():
-                if self._dialect_name == "postgresql":
-                    stmt = (
-                        pg_insert(User)
-                        .values(user_id=user_id, **values)
-                        .on_conflict_do_update(index_elements=[User.user_id], set_=values)
-                    )
-                    await session.execute(stmt)
-                elif self._dialect_name == "sqlite":
-                    stmt = (
-                        sqlite_insert(User)
-                        .values(user_id=user_id, **values)
-                        .on_conflict_do_update(index_elements=[User.user_id], set_=values)
-                    )
-                    await session.execute(stmt)
-                else:
-                    existing = await session.execute(select(User).where(User.user_id == user_id))
-                    record = existing.scalar_one_or_none()
-                    if record:
-                        await session.execute(update(User).where(User.user_id == user_id).values(**values))
-                    else:
-                        session.add(
-                            User(
-                                user_id=user_id,
-                                user_name=user_name,
-                                user_username=user_username,
-                                chat_type=chat_type,
-                                language=language,
-                                status=status,
-                            )
-                        )
+                stmt = (
+                    self._insert(User)
+                    .values(user_id=user_id, **values)
+                    .on_conflict_do_update(index_elements=[User.user_id], set_=values)
+                )
+                await session.execute(stmt)
         self._status_cache[int(user_id)] = (time.monotonic(), status)
 
     async def delete_user(self, user_id: int) -> None:
@@ -81,33 +48,6 @@ class UserRepositoryMixin:
         user_id_int = int(user_id)
         self._status_cache.pop(user_id_int, None)
         self._settings_cache.pop(user_id_int, None)
-
-    async def user_count(self) -> int:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(func.count(User.user_id)))
-            return result.scalar() or 0
-
-    async def active_user_count(self) -> int:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(func.count(User.user_id)).where(User.status == "active"))
-            return result.scalar() or 0
-
-    async def inactive_user_count(self) -> int:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(func.count(User.user_id)).where(User.status != "active"))
-            return result.scalar() or 0
-
-    async def private_chat_count(self) -> int:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(func.count(User.user_id)).where(User.chat_type == "private"))
-            return result.scalar() or 0
-
-    async def group_chat_count(self) -> int:
-        async with self.SessionLocal() as session:
-            result = await session.execute(
-                select(func.count(User.user_id)).where(User.chat_type != "private", User.chat_type.isnot(None))
-            )
-            return result.scalar() or 0
 
     async def get_user_counts(self) -> dict[str, int]:
         async with self.SessionLocal() as session:
@@ -131,39 +71,9 @@ class UserRepositoryMixin:
                 "group_chat_count": row.group_chat_count,
             }
 
-    async def all_users(self) -> list[int]:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(User.user_id))
-            return result.scalars().all()
-
-    async def user_exist(self, user_id: int) -> bool:
-        async with self.SessionLocal() as session:
-            result = await session.execute(select(User).where(User.user_id == user_id))
-            return result.scalar() is not None
-
-    async def user_update_name(self, user_id: int, user_name: str | None, user_username: str | None) -> None:
-        async with self.SessionLocal() as session:
-            async with session.begin():
-                await session.execute(
-                    update(User)
-                    .where(User.user_id == user_id)
-                    .values(user_name=user_name, user_username=user_username)
-                )
-
     async def get_user_setting(self, user_id: int, field: str) -> str | None:
         settings = await self.user_settings(user_id)
         return settings.get(field)
-
-    async def get_referral_stats(self, user_id: int) -> int:
-        async with self.SessionLocal() as session:
-            try:
-                result = await session.execute(
-                    select(func.count(User.user_id)).where(User.referred_by == int(user_id))
-                )
-                return result.scalar() or 0
-            except Exception as exc:
-                logging.error("Error in get_referral_stats: %s", exc)
-                return 0
 
     async def user_settings(self, user_id: int) -> dict[str, str]:
         user_id_int = int(user_id)
@@ -223,38 +133,15 @@ class UserRepositoryMixin:
         async with self.SessionLocal() as session:
             async with session.begin():
                 values = {"user_id": user_id_int, field: normalized_value}
-                if self._dialect_name == "postgresql":
-                    stmt = (
-                        pg_insert(Settings)
-                        .values(**values)
-                        .on_conflict_do_update(
-                            index_elements=[Settings.user_id],
-                            set_={field: normalized_value},
-                        )
+                stmt = (
+                    self._insert(Settings)
+                    .values(**values)
+                    .on_conflict_do_update(
+                        index_elements=[Settings.user_id],
+                        set_={field: normalized_value},
                     )
-                    await session.execute(stmt)
-                elif self._dialect_name == "sqlite":
-                    stmt = (
-                        sqlite_insert(Settings)
-                        .values(**values)
-                        .on_conflict_do_update(
-                            index_elements=[Settings.user_id],
-                            set_={field: normalized_value},
-                        )
-                    )
-                    await session.execute(stmt)
-                else:
-                    existing = await session.execute(
-                        select(Settings).where(Settings.user_id == user_id_int).order_by(Settings.id.desc())
-                    )
-                    setting_rows = existing.scalars().all()
-                    setting = setting_rows[0] if setting_rows else None
-                    if setting is None:
-                        setting = Settings(user_id=user_id_int)
-                        session.add(setting)
-                    setattr(setting, field, normalized_value)
-                    for duplicate in setting_rows[1:]:
-                        await session.delete(duplicate)
+                )
+                await session.execute(stmt)
         self._settings_cache.pop(user_id_int, None)
         updated = await self.user_settings(user_id_int)
         updated[field] = normalized_value
@@ -292,13 +179,6 @@ class UserRepositoryMixin:
         async with self.SessionLocal() as session:
             result = await session.execute(
                 select(User.user_name, User.user_username, User.status).where(User.user_id == user_id)
-            )
-            return result.first()
-
-    async def get_user_info_username(self, user_username: str) -> Any:
-        async with self.SessionLocal() as session:
-            result = await session.execute(
-                select(User.user_name, User.user_id, User.status).where(User.user_username == user_username)
             )
             return result.first()
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -212,6 +212,7 @@ async def test_send_to_all_message_uses_bounded_runner(monkeypatch):
             return_value=[
                 SimpleNamespace(user_id=1, status="active"),
                 SimpleNamespace(user_id=2, status="inactive"),
+                SimpleNamespace(user_id=3, status="ban"),
             ]
         )
     )
@@ -236,9 +237,57 @@ async def test_send_to_all_message_uses_bounded_runner(monkeypatch):
     await admin.send_to_all_message(message, state)
 
     run_bounded.assert_awaited_once()
-    _, kwargs = run_bounded.await_args
+    args, kwargs = run_bounded.await_args
     assert kwargs["limit"] == admin._ADMIN_MAILING_CONCURRENCY
+    assert [user.user_id for user in args[0]] == [1, 2]
     assert fake_bot.send_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_deliver_mailing_message_handles_typed_telegram_errors(monkeypatch):
+    from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+
+    fake_db = SimpleNamespace(
+        delete_user=AsyncMock(),
+        set_inactive=AsyncMock(),
+        set_active=AsyncMock(),
+    )
+
+    monkeypatch.setattr(admin, "db", fake_db)
+    monkeypatch.setattr(admin, "_ADMIN_THROTTLE_SECONDS", 0.0)
+
+    def make_bot(error):
+        async def copy_message(**_kwargs):
+            raise error
+
+        return SimpleNamespace(copy_message=copy_message)
+
+    monkeypatch.setattr(
+        admin,
+        "bot",
+        make_bot(TelegramForbiddenError(method=None, message="Forbidden: bots can't send messages to bots")),
+    )
+    await admin._deliver_mailing_message(SimpleNamespace(user_id=1, status="active"), sender_id=9, message_id=5)
+    fake_db.delete_user.assert_awaited_once_with(1)
+    fake_db.set_inactive.assert_not_awaited()
+
+    monkeypatch.setattr(
+        admin,
+        "bot",
+        make_bot(TelegramForbiddenError(method=None, message="Forbidden: bot was blocked by the user")),
+    )
+    await admin._deliver_mailing_message(SimpleNamespace(user_id=2, status="active"), sender_id=9, message_id=5)
+    fake_db.set_inactive.assert_awaited_once_with(2)
+
+    monkeypatch.setattr(
+        admin,
+        "bot",
+        make_bot(TelegramBadRequest(method=None, message="Bad Request: chat not found")),
+    )
+    await admin._deliver_mailing_message(SimpleNamespace(user_id=3, status="active"), sender_id=9, message_id=5)
+    assert fake_db.set_inactive.await_count == 2
+    fake_db.set_inactive.assert_awaited_with(3)
+    fake_db.delete_user.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_flow.py
+++ b/tests/test_audio_flow.py
@@ -1,0 +1,202 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from services.media.audio_flow import run_audio_flow
+from utils.download_manager import DownloadMetrics
+
+
+def _make_metrics(tmp_path, size=4):
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"a" * size)
+    return DownloadMetrics(
+        url="https://example.com/audio.mp3",
+        path=str(audio_path),
+        size=size,
+        elapsed=0.1,
+        used_multipart=False,
+        resumed=False,
+    )
+
+
+def _make_db(cached_file_id=None):
+    return SimpleNamespace(
+        get_file_id=AsyncMock(return_value=cached_file_id),
+        add_file=AsyncMock(),
+    )
+
+
+def _make_flow_kwargs(db, **overrides):
+    kwargs = {
+        "cache_key": "https://example.com/track#audio",
+        "db_service": db,
+        "send_cached": AsyncMock(return_value=None),
+        "download_audio": AsyncMock(return_value=None),
+        "on_missing_audio": AsyncMock(),
+        "max_file_size": 100,
+        "on_too_large": AsyncMock(),
+        "prepare_metadata": AsyncMock(
+            return_value=SimpleNamespace(thumbnail_path=None, cleanup=Mock())
+        ),
+        "send_downloaded": AsyncMock(
+            return_value=SimpleNamespace(audio=SimpleNamespace(file_id="sent-file-id"))
+        ),
+        "cleanup_path": AsyncMock(),
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_serves_cached_file():
+    db = _make_db(cached_file_id="cached-id")
+    sent_message = object()
+    on_after_send = AsyncMock()
+    kwargs = _make_flow_kwargs(
+        db,
+        send_cached=AsyncMock(return_value=sent_message),
+        on_after_send=on_after_send,
+    )
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is not None
+    assert result.from_cache is True
+    assert result.file_id == "cached-id"
+    assert result.sent_message is sent_message
+    kwargs["send_cached"].assert_awaited_once_with("cached-id")
+    kwargs["download_audio"].assert_not_awaited()
+    db.add_file.assert_not_awaited()
+    on_after_send.assert_awaited_once_with(result)
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_downloads_sends_and_caches(tmp_path):
+    db = _make_db()
+    metrics = _make_metrics(tmp_path)
+    prepared = SimpleNamespace(thumbnail_path=None, cleanup=Mock())
+    on_after_send = AsyncMock()
+    kwargs = _make_flow_kwargs(
+        db,
+        download_audio=AsyncMock(return_value=metrics),
+        prepare_metadata=AsyncMock(return_value=prepared),
+        on_after_send=on_after_send,
+    )
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is not None
+    assert result.from_cache is False
+    assert result.file_id == "sent-file-id"
+    kwargs["prepare_metadata"].assert_awaited_once_with(metrics.path)
+    kwargs["send_downloaded"].assert_awaited_once_with(metrics.path, prepared)
+    db.add_file.assert_awaited_once_with(kwargs["cache_key"], "sent-file-id", "audio")
+    prepared.cleanup.assert_called_once_with()
+    kwargs["cleanup_path"].assert_awaited_once_with(metrics.path)
+    on_after_send.assert_awaited_once_with(result)
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_reports_missing_audio():
+    db = _make_db()
+    kwargs = _make_flow_kwargs(db, download_audio=AsyncMock(return_value=None))
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is None
+    kwargs["on_missing_audio"].assert_awaited_once_with()
+    kwargs["send_downloaded"].assert_not_awaited()
+    kwargs["cleanup_path"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_reports_too_large_and_cleans_up(tmp_path):
+    db = _make_db()
+    metrics = _make_metrics(tmp_path)
+    kwargs = _make_flow_kwargs(
+        db,
+        download_audio=AsyncMock(return_value=metrics),
+        max_file_size=metrics.size,
+    )
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is None
+    kwargs["on_too_large"].assert_awaited_once_with()
+    kwargs["prepare_metadata"].assert_not_awaited()
+    kwargs["send_downloaded"].assert_not_awaited()
+    kwargs["cleanup_path"].assert_awaited_once_with(metrics.path)
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_cleans_up_when_send_fails(tmp_path):
+    db = _make_db()
+    metrics = _make_metrics(tmp_path)
+    prepared = SimpleNamespace(thumbnail_path=None, cleanup=Mock())
+    kwargs = _make_flow_kwargs(
+        db,
+        download_audio=AsyncMock(return_value=metrics),
+        prepare_metadata=AsyncMock(return_value=prepared),
+        send_downloaded=AsyncMock(side_effect=RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_audio_flow(**kwargs)
+
+    prepared.cleanup.assert_called_once_with()
+    kwargs["cleanup_path"].assert_awaited_once_with(metrics.path)
+    db.add_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_aborted_fetch_metadata_skips_download():
+    db = _make_db()
+    kwargs = _make_flow_kwargs(db, fetch_metadata=AsyncMock(return_value=False))
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is None
+    kwargs["download_audio"].assert_not_awaited()
+    kwargs["on_missing_audio"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_cache_store_error_is_delegated(tmp_path):
+    db = _make_db()
+    db.add_file = AsyncMock(side_effect=RuntimeError("db down"))
+    metrics = _make_metrics(tmp_path)
+    on_cache_store_error = AsyncMock()
+    on_after_send = AsyncMock()
+    kwargs = _make_flow_kwargs(
+        db,
+        download_audio=AsyncMock(return_value=metrics),
+        on_cache_store_error=on_cache_store_error,
+        on_after_send=on_after_send,
+    )
+
+    result = await run_audio_flow(**kwargs)
+
+    assert result is not None
+    assert result.file_id == "sent-file-id"
+    on_cache_store_error.assert_awaited_once()
+    on_after_send.assert_awaited_once_with(result)
+
+
+@pytest.mark.asyncio
+async def test_run_audio_flow_cache_store_error_propagates_without_handler(tmp_path):
+    db = _make_db()
+    db.add_file = AsyncMock(side_effect=RuntimeError("db down"))
+    metrics = _make_metrics(tmp_path)
+    prepared = SimpleNamespace(thumbnail_path=None, cleanup=Mock())
+    kwargs = _make_flow_kwargs(
+        db,
+        download_audio=AsyncMock(return_value=metrics),
+        prepare_metadata=AsyncMock(return_value=prepared),
+    )
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await run_audio_flow(**kwargs)
+
+    prepared.cleanup.assert_called_once_with()
+    kwargs["cleanup_path"].assert_awaited_once_with(metrics.path)

--- a/tests/test_bot_profile_cache.py
+++ b/tests/test_bot_profile_cache.py
@@ -1,0 +1,59 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from handlers import bot_profile_cache
+
+
+@pytest.mark.asyncio
+async def test_get_bot_avatar_thumbnail_serializes_concurrent_cold_cache_calls(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(bot_profile_cache, "_bot_username", "downloader_bot")
+    monkeypatch.setattr(bot_profile_cache, "_bot_id", 777)
+    monkeypatch.setattr(bot_profile_cache, "_bot_avatar_path", None)
+    monkeypatch.setattr(bot_profile_cache, "_bot_avatar_lock", asyncio.Lock())
+    monkeypatch.setattr(
+        bot_profile_cache, "_AUDIO_THUMB_PATH", tmp_path / "bot_audio_thumbnail.jpg"
+    )
+    photos = SimpleNamespace(
+        total_count=1,
+        photos=[
+            [
+                SimpleNamespace(
+                    file_id="small", width=160, height=160, file_size=32_000
+                )
+            ]
+        ],
+    )
+
+    async def fake_download(_file_id, destination):
+        await asyncio.sleep(0)
+        destination.write(b"image-bytes")
+
+    def fake_normalize(source_path: Path, output_path: Path) -> bool:
+        output_path.write_bytes(source_path.read_bytes())
+        return True
+
+    bot = SimpleNamespace(
+        get_user_profile_photos=AsyncMock(return_value=photos),
+        download=AsyncMock(side_effect=fake_download),
+    )
+    monkeypatch.setattr(
+        bot_profile_cache, "_normalize_audio_thumbnail_file", fake_normalize
+    )
+
+    first, second = await asyncio.gather(
+        bot_profile_cache.get_bot_avatar_thumbnail(bot),
+        bot_profile_cache.get_bot_avatar_thumbnail(bot),
+    )
+
+    assert first is not None and second is not None
+    assert first.path == second.path == str(tmp_path / "bot_audio_thumbnail.jpg")
+    assert (tmp_path / "bot_audio_thumbnail.jpg").read_bytes() == b"image-bytes"
+    # Only one cold-cache caller may download; the other must reuse the result.
+    assert bot.download.await_count == 1
+    assert bot.get_user_profile_photos.await_count == 1

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,8 +28,17 @@ def test_map_action_to_service_includes_soundcloud():
 def test_analytics_event_model_declares_stats_indexes():
     index_names = {index.name for index in db_module.AnalyticsEvent.__table__.indexes}
 
-    assert "ix_analytics_events_created_at" in index_names
     assert "ix_analytics_events_action_name_created_at" in index_names
+    assert "ix_analytics_events_created_action" in index_names
+    assert "ix_analytics_events_created_at" not in index_names
+    assert "ix_analytics_events_action_name" not in index_names
+
+
+def test_stats_period_start_is_timezone_aware_utc():
+    start = db_module.DataBase._stats_period_start("Week")
+
+    assert start.tzinfo is not None
+    assert start.utcoffset() == timedelta(0)
 
 
 def test_select_schema_migration_action_prefers_upgrade_for_empty_schema():
@@ -156,8 +165,8 @@ async def database(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_add_user_and_settings(database):
-    await database.add_user(
+async def test_upsert_chat_and_settings(database):
+    await database.upsert_chat(
         user_id=1,
         user_name="Alice",
         user_username="alice",
@@ -166,9 +175,8 @@ async def test_add_user_and_settings(database):
         status="active",
     )
 
-    assert await database.user_exist(1) is True
-
     info = await database.get_user_info(1)
+    assert info is not None
     assert info[0] == "Alice"
     assert info[1] == "alice"
     assert info[2] == "active"
@@ -238,7 +246,7 @@ async def test_upsert_chat_creates_and_updates(database):
 
 @pytest.mark.asyncio
 async def test_user_status_transitions(database):
-    await database.add_user(
+    await database.upsert_chat(
         user_id=2,
         user_name="Bob",
         user_username="bob",
@@ -257,7 +265,7 @@ async def test_user_status_transitions(database):
     assert await database.status(2) == "ban"
 
     await database.delete_user(2)
-    assert await database.user_exist(2) is False
+    assert await database.get_user_info(2) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -304,6 +304,159 @@ async def test_download_subprocess_times_out_and_kills_worker(monkeypatch, tmp_p
     assert process.communicate_calls == 2
 
 
+def test_download_single_retry_recomputes_range_offset(monkeypatch, tmp_path):
+    downloader = ResilientDownloader(
+        str(tmp_path), config=DownloadConfig(max_retries=1, retry_backoff=0.0)
+    )
+    part_path = tmp_path / "video.part"
+    part_path.write_bytes(b"0123")
+    full_payload = b"0123456789"
+    seen_ranges = []
+
+    class FlakyResponse:
+        def __init__(self, start, fail):
+            self.start = start
+            self.fail = fail
+            self.status_code = 206
+            self.headers = {
+                "content-range": f"bytes {start}-9/10",
+                "content-length": str(10 - start),
+            }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_bytes(self, chunk_size):
+            if self.fail:
+                yield full_payload[self.start : self.start + 3]
+                raise RuntimeError("connection dropped")
+            yield full_payload[self.start :]
+
+    class FlakySession:
+        def __init__(self):
+            self.calls = 0
+
+        def stream(self, method, url, headers=None, **kwargs):
+            self.calls += 1
+            seen_ranges.append(headers["Range"])
+            start = int(headers["Range"].removeprefix("bytes=").rstrip("-"))
+            return FlakyResponse(start, fail=self.calls == 1)
+
+    session = FlakySession()
+    monkeypatch.setattr(downloader, "_get_session", lambda: session)
+
+    downloader._download_single(
+        "https://cdn.example.com/video.mp4",
+        str(part_path),
+        {"Range": "bytes=4-"},
+    )
+
+    assert seen_ranges == ["bytes=4-", "bytes=7-"]
+    assert part_path.read_bytes() == full_payload
+
+
+@pytest.mark.asyncio
+async def test_download_leader_cancellation_releases_joiners(monkeypatch, tmp_path):
+    downloader = ResilientDownloader(str(tmp_path))
+    downloader._inflight_downloads.clear()
+    started = asyncio.Event()
+
+    async def hanging_submit(runner, **_kwargs):
+        started.set()
+        await asyncio.sleep(60)
+
+    def fake_queue():
+        return SimpleNamespace(submit=hanging_submit)
+
+    monkeypatch.setattr(download_manager, "get_download_queue", fake_queue)
+
+    leader = asyncio.create_task(
+        downloader.download("https://cdn.example.com/video.mp4", "video.mp4")
+    )
+    await started.wait()
+    joiner = asyncio.create_task(
+        downloader.download("https://cdn.example.com/video.mp4", "video.mp4")
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    leader.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await leader
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(joiner, timeout=1)
+
+
+def test_download_sync_discards_full_size_partial_instead_of_resuming(
+    monkeypatch, tmp_path
+):
+    downloader = ResilientDownloader(str(tmp_path))
+    temp_path = tmp_path / f"video.mp4{downloader.config.temp_suffix}"
+    temp_path.write_bytes(b"\x00" * 10)
+    seen_headers = []
+
+    monkeypatch.setattr(downloader, "_probe", lambda url, headers: (10, True))
+
+    def fake_download_single(
+        url, target_path, headers, *, progress_state=None, max_size_bytes=None
+    ):
+        seen_headers.append(dict(headers))
+        Path(target_path).write_bytes(b"0123456789")
+
+    monkeypatch.setattr(downloader, "_download_single", fake_download_single)
+
+    metrics = downloader._download_sync(
+        "https://cdn.example.com/video.mp4",
+        "video.mp4",
+        {},
+        False,
+        None,
+        None,
+    )
+
+    assert metrics.resumed is False
+    assert "Range" not in seen_headers[0]
+    assert not temp_path.exists()
+    assert (tmp_path / "video.mp4").read_bytes() == b"0123456789"
+
+
+def test_download_sync_resumes_partial_smaller_than_total(monkeypatch, tmp_path):
+    downloader = ResilientDownloader(str(tmp_path))
+    temp_path = tmp_path / f"video.mp4{downloader.config.temp_suffix}"
+    temp_path.write_bytes(b"0123")
+    seen_headers = []
+
+    monkeypatch.setattr(downloader, "_probe", lambda url, headers: (10, True))
+
+    def fake_download_single(
+        url, target_path, headers, *, progress_state=None, max_size_bytes=None
+    ):
+        seen_headers.append(dict(headers))
+        with open(target_path, "ab") as outfile:
+            outfile.write(b"456789")
+
+    monkeypatch.setattr(downloader, "_download_single", fake_download_single)
+
+    metrics = downloader._download_sync(
+        "https://cdn.example.com/video.mp4",
+        "video.mp4",
+        {},
+        False,
+        None,
+        None,
+    )
+
+    assert metrics.resumed is True
+    assert seen_headers[0]["Range"] == "bytes=4-"
+    assert (tmp_path / "video.mp4").read_bytes() == b"0123456789"
+
+
 def test_close_download_http_clients_closes_registered_clients(tmp_path):
     download_manager.close_download_http_clients()
     downloader = ResilientDownloader(str(tmp_path))

--- a/tests/test_download_queue.py
+++ b/tests/test_download_queue.py
@@ -245,6 +245,89 @@ async def test_queue_per_user_slot_race():
 
 
 @pytest.mark.asyncio
+async def test_queue_prunes_idle_scope_state():
+    queue = AdaptiveDownloadQueue(
+        min_workers=1,
+        max_workers=1,
+        per_user_rate_limit=20,
+        per_user_window_seconds=0.05,
+    )
+
+    async def job():
+        return "ok"
+
+    await queue.submit(job, priority=20, source="test", user_id=7, chat_id=123)
+    scope_key = queue._build_scope_key(7, 123)
+    assert scope_key in queue._user_recent
+    assert scope_key in queue._user_slots
+    assert scope_key in queue._user_submit_locks
+
+    await asyncio.sleep(0.06)
+    queue._prune_idle_scopes()
+
+    assert scope_key not in queue._user_recent
+    assert scope_key not in queue._user_slots
+    assert scope_key not in queue._user_submit_locks
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_queue_prune_keeps_scope_with_pending_job():
+    queue = AdaptiveDownloadQueue(
+        min_workers=1,
+        max_workers=1,
+        per_user_rate_limit=20,
+        per_user_window_seconds=0.05,
+    )
+    blocker = asyncio.Event()
+
+    async def hold():
+        await blocker.wait()
+        return "ok"
+
+    task = asyncio.create_task(queue.submit(hold, priority=20, source="test", user_id=8))
+    await asyncio.sleep(0.06)
+    queue._prune_idle_scopes()
+
+    scope_key = queue._build_scope_key(8, None)
+    assert scope_key in queue._user_slots
+    assert scope_key in queue._user_submit_locks
+
+    blocker.set()
+    assert await task == "ok"
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_queue_autotune_triggers_scope_prune():
+    from services.download.queue import _SCOPE_PRUNE_INTERVAL_SECONDS
+
+    queue = AdaptiveDownloadQueue(
+        min_workers=1,
+        max_workers=1,
+        per_user_rate_limit=20,
+        per_user_window_seconds=0.05,
+    )
+
+    async def job():
+        return "ok"
+
+    await queue.submit(job, priority=20, source="test", user_id=9)
+    scope_key = queue._build_scope_key(9, None)
+    await asyncio.sleep(0.06)
+
+    queue._last_scope_prune -= _SCOPE_PRUNE_INTERVAL_SECONDS + 1.0
+    before = queue._last_scope_prune
+    await queue._maybe_autotune()
+
+    assert queue._last_scope_prune > before
+    assert scope_key not in queue._user_recent
+    assert scope_key not in queue._user_slots
+    assert scope_key not in queue._user_submit_locks
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_request_dedupe_concurrent_same_key():
     from services.runtime.request_dedupe import claim_request, finish_request, reset_request_tracking
 

--- a/tests/test_download_worker_cli.py
+++ b/tests/test_download_worker_cli.py
@@ -81,6 +81,7 @@ def test_main_downloads_payload_and_writes_json(monkeypatch):
     monkeypatch.setattr(download_worker_cli.sys, "stdout", stdout)
     monkeypatch.setattr(download_worker_cli.sys, "stderr", stderr)
     monkeypatch.setattr(download_worker_cli, "ResilientDownloader", FakeDownloader)
+    monkeypatch.setattr(download_worker_cli, "disable_log_sinks", lambda: None)
 
     assert download_worker_cli.main() == 0
     assert stderr.getvalue() == ""
@@ -124,7 +125,24 @@ def test_main_writes_error_to_stderr(monkeypatch):
     monkeypatch.setattr(download_worker_cli.sys, "stdout", stdout)
     monkeypatch.setattr(download_worker_cli.sys, "stderr", stderr)
     monkeypatch.setattr(download_worker_cli, "ResilientDownloader", BrokenDownloader)
+    monkeypatch.setattr(download_worker_cli, "disable_log_sinks", lambda: None)
 
     assert download_worker_cli.main() == 1
     assert stdout.getvalue() == ""
     assert "boom" in stderr.getvalue()
+
+
+def test_main_disables_log_sinks_before_running(monkeypatch):
+    calls: list[bool] = []
+    monkeypatch.setattr(download_worker_cli, "disable_log_sinks", lambda: calls.append(True))
+    monkeypatch.setattr(
+        download_worker_cli.sys,
+        "stdin",
+        SimpleNamespace(buffer=io.BytesIO(b"")),
+    )
+    stderr = io.StringIO()
+    monkeypatch.setattr(download_worker_cli.sys, "stderr", stderr)
+
+    assert download_worker_cli.main() == 1
+    assert calls == [True]
+    assert "No payload provided" in stderr.getvalue()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -36,3 +36,53 @@ def test_safe_add_handler_falls_back_to_console_on_permission_error(monkeypatch)
     assert log_path in output
     assert "PermissionError" in output
 
+
+def test_third_party_loggers_route_through_app_handlers():
+    logger_module._configure_third_party_loggers()
+
+    for name, level in logger_module._THIRD_PARTY_LOG_LEVELS.items():
+        third_party = logging.getLogger(name)
+        assert third_party.propagate is False
+        assert third_party.level == level
+        for handler in logger_module._base_logger.handlers:
+            assert handler in third_party.handlers
+
+
+def test_sinks_disabled_env_parsing(monkeypatch):
+    monkeypatch.setenv(logger_module._DISABLE_SINKS_ENV, "1")
+    assert logger_module._sinks_disabled() is True
+    monkeypatch.setenv(logger_module._DISABLE_SINKS_ENV, "0")
+    assert logger_module._sinks_disabled() is False
+    monkeypatch.delenv(logger_module._DISABLE_SINKS_ENV)
+    assert logger_module._sinks_disabled() is False
+
+
+def test_disable_log_sinks_detaches_and_closes_all_sinks(monkeypatch):
+    # Register the env var with monkeypatch first so its mutation by
+    # disable_log_sinks() is rolled back after the test.
+    monkeypatch.setenv(logger_module._DISABLE_SINKS_ENV, "")
+
+    shared_handler = logging.StreamHandler(io.StringIO())
+    base = logging.getLogger("maxload-test-disable-base")
+    base.handlers.clear()
+    base.addHandler(shared_handler)
+
+    third_name = "maxload-test-disable-third"
+    third = logging.getLogger(third_name)
+    third.handlers.clear()
+    third.addHandler(shared_handler)
+
+    monkeypatch.setattr(logger_module, "_base_logger", base)
+    monkeypatch.setattr(
+        logger_module,
+        "_THIRD_PARTY_LOG_LEVELS",
+        {third_name: logging.ERROR},
+    )
+
+    logger_module.disable_log_sinks()
+
+    assert third.handlers == []
+    assert len(base.handlers) == 1
+    assert isinstance(base.handlers[0], logging.NullHandler)
+    assert logger_module._sinks_disabled() is True
+

--- a/tests/test_main_startup.py
+++ b/tests/test_main_startup.py
@@ -56,3 +56,43 @@ async def test_main_applies_polling_backpressure_settings(monkeypatch):
         allowed_updates=["message", "callback_query"],
         tasks_concurrency_limit=123,
     )
+
+
+@pytest.mark.asyncio
+async def test_main_registers_one_shared_middleware_instance_per_class(monkeypatch):
+    import middlewares
+
+    monkeypatch.setattr(main_module.bot, "get_me", AsyncMock(return_value=SimpleNamespace(username="TestBot")))
+    monkeypatch.setattr(main_module.bot, "set_my_commands", AsyncMock())
+    monkeypatch.setattr(main_module.bot, "delete_webhook", AsyncMock())
+    monkeypatch.setattr(main_module.db, "init_db", AsyncMock())
+    monkeypatch.setattr(main_module, "start_analytics_workers", AsyncMock())
+    monkeypatch.setattr(main_module, "stop_analytics_workers", AsyncMock())
+    monkeypatch.setattr(main_module, "shutdown_download_queue", AsyncMock())
+    monkeypatch.setattr(main_module, "close_http_session", AsyncMock())
+    monkeypatch.setattr(main_module.session, "close", AsyncMock())
+    monkeypatch.setattr(main_module, "set_app_context", lambda **_kwargs: None)
+    monkeypatch.setattr(main_module, "crontab", Mock())
+    monkeypatch.setattr(main_module.dp, "include_router", Mock())
+    monkeypatch.setattr(main_module.dp.message, "outer_middleware", Mock())
+    monkeypatch.setattr(main_module.dp.callback_query, "outer_middleware", Mock())
+    monkeypatch.setattr(main_module.dp.inline_query, "outer_middleware", Mock())
+    monkeypatch.setattr(main_module.dp, "resolve_used_update_types", Mock(return_value=["message"]))
+    monkeypatch.setattr(main_module.dp, "start_polling", AsyncMock(side_effect=RuntimeError("stop-polling")))
+
+    with pytest.raises(RuntimeError, match="stop-polling"):
+        await main_module.main()
+
+    message_instances = [call.args[0] for call in main_module.dp.message.outer_middleware.call_args_list]
+    callback_instances = [call.args[0] for call in main_module.dp.callback_query.outer_middleware.call_args_list]
+    inline_instances = [call.args[0] for call in main_module.dp.inline_query.outer_middleware.call_args_list]
+
+    assert len(message_instances) == len(middlewares.__all__)
+    assert len(callback_instances) == len(middlewares.__all__)
+    assert len(inline_instances) == len(middlewares.__all__)
+    for middleware_cls, message_mw, callback_mw, inline_mw in zip(
+        middlewares.__all__, message_instances, callback_instances, inline_instances
+    ):
+        assert isinstance(message_mw, middleware_cls)
+        assert message_mw is callback_mw
+        assert message_mw is inline_mw

--- a/tests/test_media_delivery.py
+++ b/tests/test_media_delivery.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import FSInputFile
 import pytest
 
@@ -298,3 +299,177 @@ async def test_send_cached_media_entries_splits_large_albums_into_multiple_batch
     assert len(second_batch_kwargs["media"]) == 2
     assert message.answer_photo.await_args.kwargs["photo"].path == "/tmp/12.jpg"
     assert db_service.add_file.await_count == 13
+
+
+@pytest.mark.asyncio
+async def test_send_cached_media_entries_probes_all_batch_videos_and_caches_group(monkeypatch):
+    probe = AsyncMock(return_value={"supports_streaming": True})
+    monkeypatch.setattr(delivery, "build_video_send_kwargs", probe)
+    message = SimpleNamespace(
+        message_id=5,
+        answer_media_group=AsyncMock(
+            return_value=[
+                SimpleNamespace(video=SimpleNamespace(file_id="album-video-0")),
+                SimpleNamespace(video=SimpleNamespace(file_id="album-video-1")),
+            ]
+        ),
+        answer_photo=AsyncMock(return_value=SimpleNamespace(photo=[SimpleNamespace(file_id="last-photo-id")])),
+        reply_photo=AsyncMock(),
+        answer_video=AsyncMock(),
+        reply_video=AsyncMock(),
+    )
+    db_service = SimpleNamespace(add_file=AsyncMock())
+    entries = [
+        {
+            "kind": "video",
+            "cache_key": "album#0",
+            "file_id": None,
+            "path": "/tmp/0.mp4",
+            "cached": False,
+        },
+        {
+            "kind": "video",
+            "cache_key": "album#1",
+            "file_id": None,
+            "path": "/tmp/1.mp4",
+            "cached": False,
+        },
+        {
+            "kind": "photo",
+            "cache_key": "album#2",
+            "file_id": None,
+            "path": "/tmp/2.jpg",
+            "cached": False,
+        },
+    ]
+
+    await send_cached_media_entries(
+        message,
+        entries,
+        db_service=db_service,
+        caption="caption",
+        reply_markup=None,
+    )
+
+    assert probe.await_count == 2
+    assert sorted(call.args[0] for call in probe.await_args_list) == ["/tmp/0.mp4", "/tmp/1.mp4"]
+    media = message.answer_media_group.await_args.kwargs["media"]
+    assert len(media) == 2
+    assert db_service.add_file.await_count == 3
+    cached_calls = {call.args[0]: call.args[1] for call in db_service.add_file.await_args_list}
+    assert cached_calls == {
+        "album#0": "album-video-0",
+        "album#1": "album-video-1",
+        "album#2": "last-photo-id",
+    }
+
+
+def _make_sender_message():
+    return SimpleNamespace(
+        reply_video=AsyncMock(
+            return_value=SimpleNamespace(
+                document=None, video=SimpleNamespace(file_id="video-file-id")
+            )
+        ),
+        reply_document=AsyncMock(
+            return_value=SimpleNamespace(
+                document=SimpleNamespace(file_id="doc-file-id"), video=None
+            )
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_video_or_document_senders_sends_cached_video():
+    message = _make_sender_message()
+    reply_markup = object()
+    send_cached, _send_downloaded, extract_file_id = (
+        delivery.make_video_or_document_senders(
+            message,
+            caption="caption",
+            reply_markup_fn=lambda: reply_markup,
+            as_document=False,
+            cached_log_label="TikTok video",
+            cached_log_url="https://www.tiktok.com/@creator/video/123",
+        )
+    )
+
+    sent = await send_cached("cached-file-id")
+
+    message.reply_video.assert_awaited_once_with(
+        video="cached-file-id",
+        caption="caption",
+        reply_markup=reply_markup,
+        parse_mode="HTML",
+    )
+    message.reply_document.assert_not_awaited()
+    assert extract_file_id(sent) == "video-file-id"
+
+
+@pytest.mark.asyncio
+async def test_make_video_or_document_senders_cached_bad_request_returns_none():
+    message = _make_sender_message()
+    message.reply_video.side_effect = TelegramBadRequest(
+        method=SimpleNamespace(__api_method__="sendVideo"),
+        message="Telegram server says - Bad Request: wrong file identifier",
+    )
+    send_cached, _send_downloaded, _extract_file_id = (
+        delivery.make_video_or_document_senders(
+            message,
+            caption=None,
+            reply_markup_fn=lambda: None,
+            as_document=False,
+            cached_log_label="TikTok video",
+        )
+    )
+
+    assert await send_cached("stale-file-id") is None
+
+
+@pytest.mark.asyncio
+async def test_make_video_or_document_senders_sends_downloaded_document(monkeypatch):
+    probe = AsyncMock(return_value={})
+    monkeypatch.setattr(delivery, "build_video_send_kwargs", probe)
+    message = _make_sender_message()
+    _send_cached, send_downloaded, extract_file_id = (
+        delivery.make_video_or_document_senders(
+            message,
+            caption="caption",
+            reply_markup_fn=lambda: None,
+            as_document=True,
+            cached_log_label="Instagram video",
+        )
+    )
+
+    sent = await send_downloaded("/tmp/video.mp4")
+
+    probe.assert_not_awaited()
+    kwargs = message.reply_document.await_args.kwargs
+    assert isinstance(kwargs["document"], FSInputFile)
+    assert kwargs["disable_content_type_detection"] is True
+    message.reply_video.assert_not_awaited()
+    assert extract_file_id(sent) == "doc-file-id"
+
+
+@pytest.mark.asyncio
+async def test_make_video_or_document_senders_sends_downloaded_video(monkeypatch):
+    probe = AsyncMock(return_value={"width": 640, "height": 360})
+    monkeypatch.setattr(delivery, "build_video_send_kwargs", probe)
+    message = _make_sender_message()
+    _send_cached, send_downloaded, _extract_file_id = (
+        delivery.make_video_or_document_senders(
+            message,
+            caption="caption",
+            reply_markup_fn=lambda: None,
+            as_document=False,
+            cached_log_label="YouTube video",
+        )
+    )
+
+    await send_downloaded("/tmp/video.mp4")
+
+    probe.assert_awaited_once_with("/tmp/video.mp4")
+    kwargs = message.reply_video.await_args.kwargs
+    assert isinstance(kwargs["video"], FSInputFile)
+    assert kwargs["width"] == 640
+    assert kwargs["height"] == 360

--- a/tests/test_media_orchestration.py
+++ b/tests/test_media_orchestration.py
@@ -1,10 +1,15 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from services.media import orchestration
-from utils.download_manager import DownloadMetrics
+from utils.download_manager import (
+    DownloadMetrics,
+    DownloadQueueBusyError,
+    DownloadRateLimitError,
+)
 
 
 class _FakeDb:
@@ -111,3 +116,166 @@ async def test_run_single_media_flow_reuses_inflight_result_for_duplicate_reques
         "follower_send_cached": 1,
         "cleanup": 1,
     }
+
+
+def _make_backpressure_handler(message, business_id, handle_download_error):
+    return orchestration.make_message_backpressure_handler(
+        message,
+        business_id,
+        build_rate_limit_text=lambda retry_after: f"rate-limit:{retry_after}",
+        build_queue_busy_text=lambda position: f"queue-busy:{position}",
+        handle_download_error=handle_download_error,
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_message_backpressure_handler_replies_with_rate_limit_text():
+    message = SimpleNamespace(reply=AsyncMock())
+    handle_download_error = AsyncMock()
+    handler = _make_backpressure_handler(message, None, handle_download_error)
+
+    await handler(DownloadRateLimitError(5.0))
+
+    message.reply.assert_awaited_once_with("rate-limit:5.0")
+    handle_download_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_make_message_backpressure_handler_replies_with_queue_busy_text():
+    message = SimpleNamespace(reply=AsyncMock())
+    handle_download_error = AsyncMock()
+    handler = _make_backpressure_handler(message, None, handle_download_error)
+
+    await handler(DownloadQueueBusyError(3))
+
+    message.reply.assert_awaited_once_with("queue-busy:3")
+    handle_download_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_make_message_backpressure_handler_uses_error_handler_for_business_chats():
+    message = SimpleNamespace(reply=AsyncMock())
+    handle_download_error = AsyncMock()
+    handler = _make_backpressure_handler(message, "biz-1", handle_download_error)
+
+    await handler(DownloadRateLimitError(5.0))
+
+    handle_download_error.assert_awaited_once_with(message, business_id="biz-1")
+    message.reply.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_make_message_backpressure_handler_reraises_unknown_errors():
+    message = SimpleNamespace(reply=AsyncMock())
+    handler = _make_backpressure_handler(message, None, AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await handler(RuntimeError("boom"))
+    message.reply.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_media_group_flow_sends_resolved_entries_and_cleans_up(tmp_path):
+    db = _FakeDb()
+    db.file_ids["cache:0:photo"] = "cached-photo-id"
+    downloaded_file = tmp_path / "item_1.mp4"
+    downloaded_file.write_bytes(b"video")
+    media_list = [
+        SimpleNamespace(url="https://cdn.example.com/1.jpg", type="photo"),
+        SimpleNamespace(url="https://cdn.example.com/2.mp4", type="video"),
+    ]
+    events: list[str] = []
+    sent_entries: list[list[dict]] = []
+    cleaned_paths: list[str] = []
+
+    async def _download_item(index, item, media_kind):
+        events.append(f"download:{index}:{media_kind}")
+        return DownloadMetrics(
+            url=item.url,
+            path=str(downloaded_file),
+            size=downloaded_file.stat().st_size,
+            elapsed=0.01,
+            used_multipart=False,
+            resumed=False,
+        )
+
+    async def _send_entries(entries):
+        events.append("send_entries")
+        sent_entries.append(entries)
+
+    async def _cleanup_path(path):
+        cleaned_paths.append(path)
+
+    async def _update_status(text):
+        events.append(f"status:{text}")
+
+    async def _on_after_send():
+        events.append("after_send")
+
+    async def _delete_status_message():
+        events.append("delete_status")
+
+    async def _on_empty():
+        events.append("empty")
+
+    result = await orchestration.run_media_group_flow(
+        media_list=media_list,
+        db_service=db,
+        kind_getter=lambda item: item.type,
+        build_cache_key=lambda index, _item, media_kind: f"cache:{index}:{media_kind}",
+        download_item=_download_item,
+        metrics_label="test_group",
+        error_label="Test",
+        update_status=_update_status,
+        upload_status_text="Uploading...",
+        send_entries=_send_entries,
+        on_empty=_on_empty,
+        delete_status_message=_delete_status_message,
+        cleanup_path=_cleanup_path,
+        on_after_send=_on_after_send,
+    )
+
+    assert result is True
+    assert "download:1:video" in events
+    assert "download:0:photo" not in events
+    assert events[-4:] == ["status:Uploading...", "send_entries", "after_send", "delete_status"]
+    assert cleaned_paths == [str(downloaded_file)]
+    entries = sent_entries[0]
+    assert entries[0]["file_id"] == "cached-photo-id"
+    assert entries[0]["cached"] is True
+    assert entries[1]["path"] == str(downloaded_file)
+    assert "empty" not in events
+
+
+@pytest.mark.asyncio
+async def test_run_media_group_flow_calls_on_empty_when_nothing_resolved():
+    db = _FakeDb()
+    events: list[str] = []
+
+    async def _download_item(_index, _item, _media_kind):
+        return None
+
+    async def _on_empty():
+        events.append("empty")
+
+    async def _fail(*_args, **_kwargs):
+        raise AssertionError("must not be called on the empty path")
+
+    result = await orchestration.run_media_group_flow(
+        media_list=[SimpleNamespace(url="https://cdn.example.com/1.jpg", type="photo")],
+        db_service=db,
+        kind_getter=lambda item: item.type,
+        build_cache_key=lambda index, _item, media_kind: f"cache:{index}:{media_kind}",
+        download_item=_download_item,
+        metrics_label="test_group",
+        error_label="Test",
+        update_status=_fail,
+        upload_status_text="Uploading...",
+        send_entries=_fail,
+        on_empty=_on_empty,
+        delete_status_message=_fail,
+        cleanup_path=_fail,
+    )
+
+    assert result is False
+    assert events == ["empty"]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -96,14 +96,9 @@ def test_user_message_formatters_include_dynamic_values():
         (admin_bm.not_groups, "group"),
         (admin_bm.finish_mailing, "complete"),
         (admin_bm.start_mailing, "Starting"),
-        (admin_bm.mailing_message, "Enter the message"),
-        (admin_bm.search_user_by, "Search user"),
-        (admin_bm.user_not_found, "not found"),
         (admin_bm.canceled, "canceled"),
         (admin_bm.your_message_sent, "sent"),
         (admin_bm.something_went_wrong, "Something went wrong"),
-        (admin_bm.enter_ban_reason, "ban reason"),
-        (admin_bm.unban_message, "unbanned"),
         (admin_bm.please_type_message, "Please type message"),
         (admin_bm.log_deleted, "Log deleted"),
         (admin_bm.active_users_check_no_targets, "no users"),
@@ -125,15 +120,6 @@ def test_admin_message_formatters_include_dynamic_values():
     assert "10" in panel
     assert "7" in panel
     assert "3" in panel
-    assert admin_bm.type_user("username") == "Type user username:"
-    info = admin_bm.return_user_info("Alice", 42, "@alice", "active")
-    assert "Alice" in info
-    assert "42" in info
-    assert "@alice" in info
-    assert "active" in info
-    assert "99" in admin_bm.successful_ban(99)
-    assert "11" in admin_bm.successful_unban(11)
-    assert "spam" in admin_bm.ban_message("spam")
     assert "55" in admin_bm.active_users_check_started(55)
     completed = admin_bm.active_users_check_completed(12, 10, 2)
     assert "12" in completed

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -138,3 +138,58 @@ def test_analytics_user_id_index_migration_creates_missing(monkeypatch):
     assert create_index.call_count == 2
     create_index.assert_any_call("ix_analytics_events_user_id", "analytics_events", ["user_id"], unique=False)
     create_index.assert_any_call("ix_downloaded_files_date_added", "downloaded_files", ["date_added"], unique=False)
+
+
+def test_redundant_analytics_index_migration_drops_only_existing(monkeypatch):
+    module = _load_migration_module("20260726_000010_drop_redundant_analytics_indexes.py")
+    drop_index = Mock()
+    monkeypatch.setattr(module.op, "drop_index", drop_index)
+    monkeypatch.setattr(module.op, "get_bind", lambda: object())
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: SimpleNamespace(
+            get_indexes=lambda _table: [
+                {"name": "ix_analytics_events_created_at"},
+                {"name": "ix_analytics_events_created_action"},
+            ]
+        ),
+    )
+
+    module.upgrade()
+
+    drop_index.assert_called_once_with("ix_analytics_events_created_at", table_name="analytics_events")
+
+
+def test_redundant_analytics_index_migration_skips_missing(monkeypatch):
+    module = _load_migration_module("20260726_000010_drop_redundant_analytics_indexes.py")
+    drop_index = Mock()
+    monkeypatch.setattr(module.op, "drop_index", drop_index)
+    monkeypatch.setattr(module.op, "get_bind", lambda: object())
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: SimpleNamespace(get_indexes=lambda _table: []),
+    )
+
+    module.upgrade()
+
+    drop_index.assert_not_called()
+
+
+def test_redundant_analytics_index_migration_downgrade_recreates_missing(monkeypatch):
+    module = _load_migration_module("20260726_000010_drop_redundant_analytics_indexes.py")
+    create_index = Mock()
+    monkeypatch.setattr(module.op, "create_index", create_index)
+    monkeypatch.setattr(module.op, "get_bind", lambda: object())
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: SimpleNamespace(get_indexes=lambda _table: []),
+    )
+
+    module.downgrade()
+
+    assert create_index.call_count == 2
+    create_index.assert_any_call("ix_analytics_events_created_at", "analytics_events", ["created_at"], unique=False)
+    create_index.assert_any_call("ix_analytics_events_action_name", "analytics_events", ["action_name"], unique=False)

--- a/tests/test_pinterest_handler.py
+++ b/tests/test_pinterest_handler.py
@@ -450,3 +450,196 @@ async def test_chosen_inline_pinterest_result_edits_inline_photo(monkeypatch):
 
     media = pinterest.safe_edit_inline_media.await_args.args[2]
     assert media.media == "cached-photo-id"
+
+
+def _inline_send_settings():
+    return {
+        "captions": "on",
+        "delete_message": "off",
+        "info_buttons": "on",
+        "url_button": "on",
+        "audio_button": "on",
+    }
+
+
+def _make_chosen_result(token, inline_message_id):
+    return SimpleNamespace(
+        result_id=f"pinterest_inline:{token}",
+        inline_message_id=inline_message_id,
+        from_user=SimpleNamespace(full_name="Inline User"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_chosen_inline_pinterest_result_uploads_photo_when_not_cached(monkeypatch):
+    token = create_inline_video_request(
+        "pinterest",
+        "https://www.pinterest.com/pin/555000111/",
+        42,
+        _inline_send_settings(),
+    )
+    result = _make_chosen_result(token, "inline-pin-photo-upload")
+    post = pinterest.PinterestPost(
+        id="pin-photo-upload",
+        description="fresh photo pin",
+        media_list=[pinterest.PinterestMedia(url="https://cdn.example.com/photo.jpg", type="photo")],
+    )
+
+    sent_photo = SimpleNamespace(photo=[SimpleNamespace(file_id="fresh-photo-id")])
+    monkeypatch.setattr(pinterest, "CHANNEL_ID", -1001234567890)
+    monkeypatch.setattr(pinterest, "bot", SimpleNamespace(send_photo=AsyncMock(return_value=sent_photo)))
+    monkeypatch.setattr(pinterest.pinterest_service, "fetch_post", AsyncMock(return_value=post))
+    monkeypatch.setattr(pinterest.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(pinterest.db, "add_file", AsyncMock())
+    monkeypatch.setattr(pinterest, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_media", AsyncMock(return_value=True))
+
+    await pinterest.chosen_inline_pinterest_result(result)
+
+    pinterest.bot.send_photo.assert_awaited_once()
+    assert pinterest.bot.send_photo.await_args.kwargs["chat_id"] == -1001234567890
+    pinterest.db.add_file.assert_awaited_once_with(
+        "https://www.pinterest.com/pin/555000111/#photo", "fresh-photo-id", "photo"
+    )
+    media = pinterest.safe_edit_inline_media.await_args.args[2]
+    assert media.media == "fresh-photo-id"
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "completed"
+
+
+@pytest.mark.asyncio
+async def test_chosen_inline_pinterest_result_downloads_and_uploads_video(monkeypatch, tmp_path):
+    token = create_inline_video_request(
+        "pinterest",
+        "https://www.pinterest.com/pin/555000222/",
+        42,
+        _inline_send_settings(),
+    )
+    result = _make_chosen_result(token, "inline-pin-video-upload")
+    post = pinterest.PinterestPost(
+        id="pin-video-upload",
+        description="fresh video pin",
+        media_list=[pinterest.PinterestMedia(url="https://cdn.example.com/video.mp4", type="video")],
+    )
+
+    download_file = tmp_path / "pin-inline.mp4"
+    download_file.write_bytes(b"video-bytes")
+    metrics = DownloadMetrics(
+        url="https://cdn.example.com/video.mp4",
+        path=str(download_file),
+        size=download_file.stat().st_size,
+        elapsed=0.01,
+        used_multipart=False,
+        resumed=False,
+    )
+
+    sent_video = SimpleNamespace(video=SimpleNamespace(file_id="fresh-video-id"))
+    monkeypatch.setattr(pinterest, "CHANNEL_ID", -1001234567890)
+    monkeypatch.setattr(pinterest, "bot", SimpleNamespace(send_video=AsyncMock(return_value=sent_video)))
+    monkeypatch.setattr(pinterest.pinterest_service, "fetch_post", AsyncMock(return_value=post))
+    monkeypatch.setattr(pinterest.pinterest_service, "download_media", AsyncMock(return_value=metrics))
+    monkeypatch.setattr(pinterest.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(pinterest.db, "add_file", AsyncMock())
+    monkeypatch.setattr(pinterest, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_media", AsyncMock(return_value=True))
+
+    await pinterest.chosen_inline_pinterest_result(result)
+
+    pinterest.bot.send_video.assert_awaited_once()
+    pinterest.db.add_file.assert_awaited_once_with(
+        "https://www.pinterest.com/pin/555000222/", "fresh-video-id", "video"
+    )
+    media = pinterest.safe_edit_inline_media.await_args.args[2]
+    assert media.media == "fresh-video-id"
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "completed"
+    assert not download_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_chosen_inline_pinterest_result_completes_when_video_too_large(monkeypatch, tmp_path):
+    token = create_inline_video_request(
+        "pinterest",
+        "https://www.pinterest.com/pin/555000333/",
+        42,
+        _inline_send_settings(),
+    )
+    result = _make_chosen_result(token, "inline-pin-video-too-large")
+    post = pinterest.PinterestPost(
+        id="pin-video-too-large",
+        description="huge video pin",
+        media_list=[pinterest.PinterestMedia(url="https://cdn.example.com/video.mp4", type="video")],
+    )
+
+    download_file = tmp_path / "pin-too-large.mp4"
+    download_file.write_bytes(b"video-bytes")
+    metrics = DownloadMetrics(
+        url="https://cdn.example.com/video.mp4",
+        path=str(download_file),
+        size=download_file.stat().st_size,
+        elapsed=0.01,
+        used_multipart=False,
+        resumed=False,
+    )
+
+    monkeypatch.setattr(pinterest, "CHANNEL_ID", -1001234567890)
+    monkeypatch.setattr(pinterest, "MAX_FILE_SIZE", metrics.size)
+    monkeypatch.setattr(pinterest, "bot", SimpleNamespace(send_video=AsyncMock()))
+    monkeypatch.setattr(pinterest.pinterest_service, "fetch_post", AsyncMock(return_value=post))
+    monkeypatch.setattr(pinterest.pinterest_service, "download_media", AsyncMock(return_value=metrics))
+    monkeypatch.setattr(pinterest.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(pinterest.db, "add_file", AsyncMock())
+    monkeypatch.setattr(pinterest, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_media", AsyncMock(return_value=True))
+
+    await pinterest.chosen_inline_pinterest_result(result)
+
+    pinterest.bot.send_video.assert_not_awaited()
+    last_edit = pinterest.safe_edit_inline_text.await_args_list[-1]
+    assert last_edit.args[2] == pinterest.bm.video_too_large()
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "completed"
+    assert not download_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_chosen_inline_pinterest_result_resets_when_download_fails(monkeypatch):
+    token = create_inline_video_request(
+        "pinterest",
+        "https://www.pinterest.com/pin/555000444/",
+        42,
+        _inline_send_settings(),
+    )
+    result = _make_chosen_result(token, "inline-pin-video-failed")
+    post = pinterest.PinterestPost(
+        id="pin-video-failed",
+        description="broken video pin",
+        media_list=[pinterest.PinterestMedia(url="https://cdn.example.com/video.mp4", type="video")],
+    )
+
+    monkeypatch.setattr(pinterest, "CHANNEL_ID", -1001234567890)
+    monkeypatch.setattr(pinterest, "bot", SimpleNamespace(send_video=AsyncMock()))
+    monkeypatch.setattr(pinterest.pinterest_service, "fetch_post", AsyncMock(return_value=post))
+    monkeypatch.setattr(pinterest.pinterest_service, "download_media", AsyncMock(return_value=None))
+    monkeypatch.setattr(pinterest.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(pinterest.db, "add_file", AsyncMock())
+    monkeypatch.setattr(pinterest, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(pinterest, "safe_edit_inline_media", AsyncMock(return_value=True))
+
+    await pinterest.chosen_inline_pinterest_result(result)
+
+    pinterest.bot.send_video.assert_not_awaited()
+    pinterest.db.add_file.assert_not_awaited()
+    last_edit = pinterest.safe_edit_inline_text.await_args_list[-1]
+    assert last_edit.args[2] == pinterest.bm.something_went_wrong()
+    assert last_edit.kwargs["reply_markup"] is not None
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "pending"

--- a/tests/test_platform_services.py
+++ b/tests/test_platform_services.py
@@ -1,0 +1,267 @@
+from pathlib import Path
+
+import pytest
+
+from services.platforms import CobaltMediaService, strip_url_query
+from services.platforms.ytdlp_helpers import (
+    mp3_extract_postprocessors,
+    resolve_downloaded_path,
+    run_ytdlp_download,
+)
+from tests.conftest import FakeYoutubeDL
+from utils.cobalt_media import extract_cobalt_thumb, parse_cobalt_media_response
+from utils.download_manager import (
+    DownloadError,
+    DownloadMetrics,
+    DownloadRateLimitError,
+)
+
+
+def test_strip_url_query_drops_query_and_fragment():
+    url = "https://example.com/p/abc/?utm_source=share#frag"
+    assert strip_url_query(url) == "https://example.com/p/abc/"
+    assert strip_url_query("not a url") == "not a url"
+
+
+def test_extract_cobalt_thumb_prefers_known_keys():
+    assert extract_cobalt_thumb({"thumb": "https://cdn.example.com/t.jpg"}) == "https://cdn.example.com/t.jpg"
+    assert extract_cobalt_thumb({"cover": "https://cdn.example.com/c.jpg"}) == "https://cdn.example.com/c.jpg"
+    assert extract_cobalt_thumb({"thumb": "", "other": "x"}) is None
+
+
+def test_parse_cobalt_media_response_tunnel():
+    payload = {"status": "tunnel", "url": "https://cdn.example.com/video.mp4"}
+
+    parsed = parse_cobalt_media_response(payload)
+
+    assert parsed is not None
+    assert parsed.status == "tunnel"
+    assert parsed.items == [("https://cdn.example.com/video.mp4", "video", None)]
+
+
+def test_parse_cobalt_media_response_infers_status_from_payload_shape():
+    parsed = parse_cobalt_media_response({"url": "https://cdn.example.com/photo.jpg"})
+
+    assert parsed is not None
+    assert parsed.status == "tunnel"
+    assert parsed.items == [("https://cdn.example.com/photo.jpg", "photo", None)]
+
+
+def test_parse_cobalt_media_response_picker():
+    payload = {
+        "status": "picker",
+        "picker": [
+            {"type": "photo", "url": "https://cdn.example.com/1.jpg", "thumb": "https://cdn.example.com/1t.jpg"},
+            {"type": "video", "url": "https://cdn.example.com/2.mp4"},
+            "junk",
+            {"type": "photo"},
+        ],
+    }
+
+    parsed = parse_cobalt_media_response(payload)
+
+    assert parsed is not None
+    assert parsed.items == [
+        ("https://cdn.example.com/1.jpg", "photo", "https://cdn.example.com/1t.jpg"),
+        ("https://cdn.example.com/2.mp4", "video", None),
+    ]
+
+
+def test_parse_cobalt_media_response_audio_only_uses_picker_audio():
+    payload = {
+        "status": "picker",
+        "audio": "https://cdn.example.com/track.mp3",
+        "picker": [{"type": "photo", "url": "https://cdn.example.com/1.jpg"}],
+    }
+
+    parsed = parse_cobalt_media_response(payload, audio_only=True)
+
+    assert parsed is not None
+    assert parsed.items == [("https://cdn.example.com/track.mp3", "audio", None)]
+
+
+def test_parse_cobalt_media_response_local_processing_single_tunnel():
+    payload = {
+        "status": "local-processing",
+        "type": "merge",
+        "tunnel": ["https://cdn.example.com/tunnel-1"],
+        "output": {"filename": "clip.mp4", "type": "video/mp4"},
+    }
+
+    parsed = parse_cobalt_media_response(payload)
+
+    assert parsed is not None
+    assert parsed.items == [("https://cdn.example.com/tunnel-1", "video", None)]
+
+
+def test_parse_cobalt_media_response_rejects_multi_tunnel_by_default():
+    payload = {
+        "status": "local-processing",
+        "type": "merge",
+        "tunnel": ["https://cdn.example.com/t1", "https://cdn.example.com/t2"],
+        "output": {"filename": "clip.mp4", "type": "video/mp4"},
+    }
+
+    assert parse_cobalt_media_response(payload) is None
+
+    parsed = parse_cobalt_media_response(payload, allow_multi_tunnel=True)
+    assert parsed is not None
+    assert [item[0] for item in parsed.items] == [
+        "https://cdn.example.com/t1",
+        "https://cdn.example.com/t2",
+    ]
+
+
+def test_parse_cobalt_media_response_returns_none_on_error_and_unsupported():
+    assert parse_cobalt_media_response({"status": "error", "error": {"code": "x"}}) is None
+    assert parse_cobalt_media_response({"status": "mystery"}) is None
+    assert parse_cobalt_media_response({"status": "tunnel"}) is None
+    assert parse_cobalt_media_response({"status": "local-processing", "tunnel": []}) is None
+    assert parse_cobalt_media_response("not a dict") is None
+
+
+def _make_cobalt_service(tmp_path: Path, *, fetch_cobalt_data_func=None, download_headers=None) -> CobaltMediaService:
+    async def passthrough_retry(operation, **_kwargs):
+        return await operation()
+
+    class _Logger:
+        def __init__(self):
+            self.calls = []
+
+        def error(self, message, *args):
+            self.calls.append((message, args))
+
+    service = CobaltMediaService(
+        str(tmp_path),
+        source="testsource",
+        retry_async_operation_func=passthrough_retry,
+        logger=_Logger(),
+        download_error_message="Error downloading test media: url=%s error=%s",
+        cobalt_api_url="https://cobalt.test",
+        cobalt_api_key="key",
+        fetch_cobalt_data_func=fetch_cobalt_data_func,
+        download_headers=download_headers,
+    )
+    return service
+
+
+@pytest.mark.asyncio
+async def test_cobalt_media_service_fetch_cobalt_json_passes_source_and_defaults(tmp_path):
+    captured = {}
+
+    async def fake_fetch(base_url, api_key, payload, **kwargs):
+        captured["base_url"] = base_url
+        captured["api_key"] = api_key
+        captured["payload"] = payload
+        captured["kwargs"] = kwargs
+        return {"status": "tunnel"}
+
+    service = _make_cobalt_service(tmp_path, fetch_cobalt_data_func=fake_fetch)
+
+    data = await service._fetch_cobalt_json({"url": "https://example.com/post"})
+
+    assert data == {"status": "tunnel"}
+    assert captured["base_url"] == "https://cobalt.test"
+    assert captured["api_key"] == "key"
+    assert captured["kwargs"] == {"source": "testsource", "timeout": 15, "attempts": 3}
+
+
+@pytest.mark.asyncio
+async def test_cobalt_media_service_download_media_success_passes_headers(tmp_path, monkeypatch):
+    headers = {"Referer": "https://example.com/"}
+    service = _make_cobalt_service(tmp_path, download_headers=headers)
+    captured = {}
+
+    async def fake_download(url, filename, **kwargs):
+        captured["url"] = url
+        captured["filename"] = filename
+        captured["kwargs"] = kwargs
+        path = tmp_path / filename
+        path.write_bytes(b"data")
+        return DownloadMetrics(
+            url=url,
+            path=str(path),
+            size=4,
+            elapsed=0.01,
+            used_multipart=False,
+            resumed=False,
+        )
+
+    monkeypatch.setattr(service._downloader, "download", fake_download)
+
+    metrics = await service.download_media("https://cdn.example.com/v.mp4", "v.mp4", user_id=7)
+
+    assert metrics is not None
+    assert captured["kwargs"]["headers"] == headers
+    assert captured["kwargs"]["user_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_cobalt_media_service_download_media_logs_and_returns_none_on_download_error(tmp_path, monkeypatch):
+    service = _make_cobalt_service(tmp_path)
+
+    async def fake_download(*_args, **_kwargs):
+        raise DownloadError("boom")
+
+    monkeypatch.setattr(service._downloader, "download", fake_download)
+
+    assert await service.download_media("https://cdn.example.com/v.mp4", "v.mp4") is None
+    assert len(service._logger.calls) == 1
+    message, args = service._logger.calls[0]
+    assert message == "Error downloading test media: url=%s error=%s"
+    assert args[0] == "https://cdn.example.com/v.mp4"
+    assert isinstance(args[1], DownloadError)
+
+
+@pytest.mark.asyncio
+async def test_cobalt_media_service_download_media_reraises_backpressure(tmp_path, monkeypatch):
+    service = _make_cobalt_service(tmp_path)
+
+    async def fake_download(*_args, **_kwargs):
+        raise DownloadRateLimitError(retry_after=5)
+
+    monkeypatch.setattr(service._downloader, "download", fake_download)
+
+    with pytest.raises(DownloadRateLimitError):
+        await service.download_media("https://cdn.example.com/v.mp4", "v.mp4")
+
+
+def test_resolve_downloaded_path_returns_exact_or_sibling_match(tmp_path):
+    exact = tmp_path / "video.mp4"
+    exact.write_bytes(b"x")
+    assert resolve_downloaded_path(str(exact)) == str(exact)
+
+    expected = tmp_path / "clip.mp4"
+    actual = tmp_path / "clip.mkv"
+    actual.write_bytes(b"x")
+    assert resolve_downloaded_path(str(expected)) == str(actual)
+
+
+def test_resolve_downloaded_path_raises_when_output_missing(tmp_path):
+    with pytest.raises(DownloadError):
+        resolve_downloaded_path(str(tmp_path / "missing.mp4"))
+
+
+def test_run_ytdlp_download_uses_factory_and_downloads_url(tmp_path):
+    created = {}
+
+    def factory(options):
+        ydl = FakeYoutubeDL(options, ext="mp4", payload=b"bytes")
+        created["ydl"] = ydl
+        return ydl
+
+    output_path = tmp_path / "video.mp4"
+    run_ytdlp_download(factory, "https://example.com/watch", {"outtmpl": str(output_path)})
+
+    assert created["ydl"].urls == ["https://example.com/watch"]
+    assert output_path.read_bytes() == b"bytes"
+
+
+def test_mp3_extract_postprocessors_returns_fresh_copies():
+    first = mp3_extract_postprocessors()
+    second = mp3_extract_postprocessors()
+
+    assert first == [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3", "preferredquality": "192"}]
+    assert first is not second
+    first[0]["preferredquality"] = "64"
+    assert mp3_extract_postprocessors()[0]["preferredquality"] == "192"

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -23,6 +23,54 @@ def _configure_runtime_state(monkeypatch, tmp_path, *modules):
     return state_file
 
 
+def test_state_store_flushes_synchronously_without_event_loop(monkeypatch, tmp_path):
+    state_file = tmp_path / "runtime_state.json"
+    monkeypatch.setattr(runtime_state_store, "_STATE_FILE", state_file)
+
+    runtime_state_store.save_bucket("demo_bucket", {"key": "value"})
+
+    assert state_file.exists()
+    assert '"demo_bucket"' in state_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_state_store_offloads_writes_to_background_flush_on_event_loop(monkeypatch, tmp_path):
+    state_file = tmp_path / "runtime_state.json"
+    monkeypatch.setattr(runtime_state_store, "_STATE_FILE", state_file)
+
+    runtime_state_store.save_bucket("demo_bucket", {"key": "value"})
+    runtime_state_store.save_bucket("demo_bucket", {"key": "updated"})
+
+    flush_task = runtime_state_store._flush_task
+    assert flush_task is not None
+    await flush_task
+
+    persisted = state_file.read_text(encoding="utf-8")
+    assert '"updated"' in persisted
+    assert runtime_state_store.load_bucket("demo_bucket", dict) == {"key": "updated"}
+
+
+def test_state_store_serves_reads_from_memory_cache(monkeypatch, tmp_path):
+    state_file = tmp_path / "runtime_state.json"
+    monkeypatch.setattr(runtime_state_store, "_STATE_FILE", state_file)
+
+    runtime_state_store.save_bucket("demo_bucket", {"key": "value"})
+    state_file.unlink()
+
+    assert runtime_state_store.load_bucket("demo_bucket", dict) == {"key": "value"}
+
+
+def test_state_store_cache_invalidated_when_state_file_changes(monkeypatch, tmp_path):
+    first_file = tmp_path / "first_state.json"
+    monkeypatch.setattr(runtime_state_store, "_STATE_FILE", first_file)
+    runtime_state_store.save_bucket("demo_bucket", {"key": "value"})
+
+    second_file = tmp_path / "second_state.json"
+    monkeypatch.setattr(runtime_state_store, "_STATE_FILE", second_file)
+
+    assert runtime_state_store.load_bucket("demo_bucket", dict) == {}
+
+
 def test_pending_requests_store_get_and_pop(monkeypatch):
     monkeypatch.setattr(pending_requests, "_pending", {})
     monkeypatch.setattr(pending_requests, "_loaded", True)

--- a/tests/test_threads_handler.py
+++ b/tests/test_threads_handler.py
@@ -67,6 +67,22 @@ def test_parse_threads_post_html_keeps_text_only_post():
     assert post.media_list == []
 
 
+def test_parse_threads_post_html_falls_back_when_blob_is_not_minified():
+    # The raw-text fast path expects minified '"code":"X"'; a blob with spaces
+    # must still be found via the parse-all fallback.
+    page = (
+        '<script type="application/json" data-sjs>'
+        '{"post": {"code": "spaced", "caption": {"text": "Spaced text"}, "user": {"username": "author"}}}'
+        "</script>"
+    )
+
+    post = parse_threads_post_html(page, "spaced")
+
+    assert post is not None
+    assert post.id == "spaced"
+    assert post.description == "Spaced text"
+
+
 @pytest.mark.asyncio
 async def test_threads_service_fetches_canonical_post_url(tmp_path):
     requested_urls: list[str] = []

--- a/tests/test_tiktok_handler.py
+++ b/tests/test_tiktok_handler.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from handlers import telegram_ui_utils, tiktok
+from services.media import delivery
 from services.inline.album_links import get_inline_album_request
 from services.inline.video_requests import (
+    claim_inline_video_request,
     create_inline_video_request,
     get_inline_video_request,
 )
@@ -70,6 +72,44 @@ async def test_process_tiktok_url_returns_original_on_error(monkeypatch):
     )
     result = await tiktok.process_tiktok_url_async(original_url)
     assert result == original_url
+
+
+@pytest.mark.asyncio
+async def test_process_tiktok_url_coalesces_concurrent_expansions(monkeypatch):
+    expected_url = "https://www.tiktok.com/@user/video/123456"
+    head_calls = []
+    release = asyncio.Event()
+
+    class SlowResponse:
+        def __init__(self, url):
+            self.url = url
+
+        async def __aenter__(self):
+            await release.wait()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_head(url, allow_redirects, headers, timeout=None):
+        head_calls.append(url)
+        return SlowResponse(expected_url)
+
+    monkeypatch.setattr(
+        tiktok,
+        "get_http_session",
+        AsyncMock(return_value=DummySession(head_handler=fake_head)),
+    )
+
+    short_url = "https://vm.tiktok.com/ABC123/"
+    first = asyncio.create_task(tiktok.process_tiktok_url_async(short_url))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(tiktok.process_tiktok_url_async(short_url))
+    await asyncio.sleep(0)
+    release.set()
+
+    assert await asyncio.gather(first, second) == [expected_url, expected_url]
+    assert head_calls == [short_url]
 
 
 @pytest.mark.asyncio
@@ -232,7 +272,9 @@ async def test_process_tiktok_video_reuses_inflight_download_across_business_cha
         "download_video",
         AsyncMock(side_effect=fake_download_video),
     )
-    monkeypatch.setattr(tiktok, "build_video_send_kwargs", AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        delivery, "build_video_send_kwargs", AsyncMock(return_value={})
+    )
     monkeypatch.setattr(tiktok, "send_chat_action_if_needed", AsyncMock())
     monkeypatch.setattr(tiktok, "safe_delete_message", AsyncMock())
     monkeypatch.setattr(tiktok, "maybe_delete_user_message", AsyncMock())
@@ -337,6 +379,49 @@ async def test_process_tiktok_photos_replies_only_on_first_sent_message(monkeypa
     )
     assert message.reply_photo.await_count == 0
     assert tiktok.db.add_file.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_download_tiktok_doc_callback_uses_pressing_user_settings(monkeypatch):
+    settings = {
+        "captions": "on",
+        "delete_message": "off",
+        "info_buttons": "off",
+        "url_button": "off",
+        "audio_button": "off",
+        "as_document": "off",
+    }
+    call = SimpleNamespace(
+        data="doc:tiktok:123",
+        from_user=SimpleNamespace(id=42),
+        answer=AsyncMock(),
+        message=SimpleNamespace(
+            # call.message is authored by the bot, not the pressing user.
+            from_user=SimpleNamespace(id=999999, is_bot=True),
+            chat=SimpleNamespace(id=42, type="private"),
+            business_connection_id=None,
+        ),
+    )
+
+    monkeypatch.setattr(tiktok.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(tiktok.db, "user_settings", AsyncMock(return_value=settings))
+    monkeypatch.setattr(
+        tiktok,
+        "fetch_tiktok_data_with_retry",
+        AsyncMock(return_value={"error": None, "code": 0, "data": {"id": "123"}}),
+    )
+    monkeypatch.setattr(
+        tiktok, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot")
+    )
+    process_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(tiktok, "process_tiktok_video", process_mock)
+
+    await tiktok.download_tiktok_doc_callback(call)
+
+    tiktok.db.user_settings.assert_awaited_once_with(42)
+    assert process_mock.await_args.kwargs["actor_user_id"] == 42
+    override_settings = process_mock.await_args.args[3]
+    assert override_settings["as_document"] == "on"
 
 
 @pytest.mark.asyncio
@@ -781,3 +866,83 @@ async def test_chosen_inline_tiktok_result_edits_inline_photo(monkeypatch):
     request = get_inline_video_request(token)
     assert request is not None
     assert request.state == "completed"
+
+
+def _make_inline_send_call(data: str, inline_message_id):
+    return SimpleNamespace(
+        data=data,
+        inline_message_id=inline_message_id,
+        id="callback-1",
+        from_user=SimpleNamespace(id=42, full_name="Inline User"),
+        message=None,
+        answer=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_inline_tiktok_video_callback_requires_inline_message_id():
+    call = _make_inline_send_call("inline:tiktok:some-token", None)
+
+    await tiktok.send_inline_tiktok_video_callback(call)
+
+    call.answer.assert_awaited_once_with(
+        "This button works only in inline mode.", show_alert=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_inline_tiktok_video_callback_reports_already_processing():
+    settings = {
+        "captions": "on",
+        "delete_message": "off",
+        "info_buttons": "on",
+        "url_button": "on",
+        "audio_button": "on",
+    }
+    token = create_inline_video_request(
+        "tiktok",
+        "https://www.tiktok.com/@creator/video/123",
+        42,
+        settings,
+    )
+    claim_inline_video_request(token)
+
+    call = _make_inline_send_call(f"inline:tiktok:{token}", "inline-message-cb")
+
+    await tiktok.send_inline_tiktok_video_callback(call)
+
+    assert call.answer.await_count == 2
+    last_answer = call.answer.await_args_list[-1]
+    assert last_answer.args == (tiktok.bm.inline_video_already_processing(),)
+    assert last_answer.kwargs == {"show_alert": False}
+
+
+@pytest.mark.asyncio
+async def test_run_inline_send_callback_alerts_on_unknown_value_error():
+    from handlers.inline_utils import run_inline_send_callback
+
+    sender = AsyncMock(side_effect=ValueError("boom"))
+    call = _make_inline_send_call("inline:tiktok:some-token", "inline-message-cb")
+
+    await run_inline_send_callback(call, "inline:tiktok:", sender)
+
+    sender.assert_awaited_once()
+    assert sender.await_args.kwargs["token"] == "some-token"
+    assert sender.await_args.kwargs["duplicate_handler"] == "callback"
+    last_answer = call.answer.await_args_list[-1]
+    assert last_answer.args == (tiktok.bm.something_went_wrong(),)
+    assert last_answer.kwargs == {"show_alert": True}
+
+
+@pytest.mark.asyncio
+async def test_run_inline_send_callback_alerts_on_permission_error():
+    from handlers.inline_utils import run_inline_send_callback
+
+    sender = AsyncMock(side_effect=PermissionError("token_owner_mismatch"))
+    call = _make_inline_send_call("inline:tiktok:some-token", "inline-message-cb")
+
+    await run_inline_send_callback(call, "inline:tiktok:", sender)
+
+    last_answer = call.answer.await_args_list[-1]
+    assert last_answer.args == (tiktok.bm.something_went_wrong(),)
+    assert last_answer.kwargs == {"show_alert": True}

--- a/tests/test_tiktok_media_service.py
+++ b/tests/test_tiktok_media_service.py
@@ -65,6 +65,59 @@ def test_tiktok_ytdlp_download_options_do_not_retry_inside_service_attempt(tmp_p
     assert options["fragment_retries"] == 0
 
 
+def test_tiktok_ie_exposes_private_web_data_extractor():
+    from yt_dlp.extractor.tiktok import TikTokIE
+
+    assert callable(getattr(TikTokIE, "_extract_web_data_and_status", None))
+
+
+def test_extract_tiktok_detail_sync_degrades_when_extractor_internals_change(tmp_path, monkeypatch):
+    service = _make_service(tmp_path)
+
+    class BrokenTikTokIE:
+        def __init__(self, _ydl):
+            pass
+
+        def _extract_web_data_and_status(self, *_args, **_kwargs):
+            raise TypeError("signature changed")
+
+    monkeypatch.setattr(
+        "services.platforms.tiktok_metadata_mixin.TikTokIE", BrokenTikTokIE
+    )
+
+    detail, status = service._extract_tiktok_detail_sync(
+        "https://www.tiktok.com/@creator/video/123"
+    )
+
+    assert detail == {}
+    assert status == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_info_sleeps_between_missing_sec_uid_retries(tmp_path, monkeypatch):
+    service = _make_service(tmp_path)
+    service.USER_LOOKUP_MAX_RETRIES = 3
+    service.USER_LOOKUP_RETRY_DELAY_SECONDS = 0.01
+
+    fake_session = _FakeSession({"nickname": "someone"})
+    service._get_http_session = AsyncMock(return_value=fake_session)
+
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(
+        "services.platforms.tiktok_profile_mixin.asyncio.sleep", fake_sleep
+    )
+
+    result = await service.fetch_user_info("missing_user")
+
+    assert result is None
+    assert len(fake_session.get_calls) == 3
+    assert sleeps == [0.01, 0.01, 0.01]
+
+
 @pytest.mark.asyncio
 async def test_fetch_tiktok_data_builds_legacy_video_payload(tmp_path, monkeypatch):
     service = _make_service(tmp_path)

--- a/tests/test_twitter_handler.py
+++ b/tests/test_twitter_handler.py
@@ -1,11 +1,11 @@
 import os
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from aiohttp.client_exceptions import ClientResponseError
 
-from handlers import twitter
+from handlers import twitter, twitter_inline
 from services.inline.album_links import get_inline_album_request
 from utils.download_manager import DownloadMetrics
 
@@ -138,7 +138,7 @@ async def test_reply_media_uses_cached_file_id_for_single_video(monkeypatch):
     monkeypatch.setattr(twitter, "safe_edit_text", AsyncMock(return_value=True))
     monkeypatch.setattr(twitter, "maybe_delete_user_message", AsyncMock())
 
-    await twitter.reply_media(
+    delivered = await twitter.reply_media(
         message,
         "123",
         tweet_media,
@@ -147,12 +147,117 @@ async def test_reply_media_uses_cached_file_id_for_single_video(monkeypatch):
         {"delete_message": "off", "info_buttons": "off", "url_button": "off", "audio_button": "off"},
     )
 
+    assert delivered is True
     assert twitter.twitter_downloader.download.await_count == 0
     assert message.reply_video.await_args.kwargs["video"] == "cached-file-id"
 
 
 @pytest.mark.asyncio
-async def test_collect_media_entries_only_downloads_cache_misses(monkeypatch, tmp_path):
+async def test_reply_media_returns_false_when_flow_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(twitter, "OUTPUT_DIR", str(tmp_path))
+    status_message = SimpleNamespace(delete=AsyncMock())
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=42),
+        chat=SimpleNamespace(id=99, type="private"),
+        message_id=7,
+        answer=AsyncMock(return_value=status_message),
+        reply=AsyncMock(),
+    )
+    tweet_media = {
+        "tweetURL": "https://x.com/user/status/123",
+        "text": "caption",
+        "likes": 1,
+        "replies": 2,
+        "retweets": 3,
+    }
+
+    monkeypatch.setattr(twitter, "send_analytics", AsyncMock())
+    monkeypatch.setattr(twitter, "_collect_media_entries", AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(twitter, "safe_delete_message", AsyncMock())
+    monkeypatch.setattr(twitter, "react_to_message", AsyncMock())
+
+    delivered = await twitter.reply_media(
+        message,
+        "123",
+        tweet_media,
+        "https://t.me/maxloadbot",
+        None,
+        {"delete_message": "off", "info_buttons": "off", "url_button": "off", "audio_button": "off"},
+    )
+
+    assert delivered is False
+    message.reply.assert_awaited_with(twitter.bm.something_went_wrong())
+
+
+@pytest.mark.asyncio
+async def test_reply_media_uses_request_unique_download_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(twitter, "OUTPUT_DIR", str(tmp_path))
+    status_message = SimpleNamespace(delete=AsyncMock())
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=42),
+        chat=SimpleNamespace(id=99, type="private"),
+        message_id=7,
+        answer=AsyncMock(return_value=status_message),
+        reply=AsyncMock(),
+    )
+    tweet_media = {
+        "tweetURL": "https://x.com/user/status/123",
+        "text": "caption",
+        "likes": 1,
+        "replies": 2,
+        "retweets": 3,
+    }
+
+    monkeypatch.setattr(twitter, "send_analytics", AsyncMock())
+    collect_entries = AsyncMock(return_value=[])
+    monkeypatch.setattr(twitter, "_collect_media_entries", collect_entries)
+    monkeypatch.setattr(twitter, "safe_delete_message", AsyncMock())
+
+    delivered = await twitter.reply_media(
+        message,
+        "123",
+        tweet_media,
+        "https://t.me/maxloadbot",
+        None,
+        {"delete_message": "off", "info_buttons": "off", "url_button": "off", "audio_button": "off"},
+    )
+
+    assert delivered is True
+    assert collect_entries.await_args.kwargs["download_dir_name"] == "123_99_7"
+
+
+@pytest.mark.asyncio
+async def test_collect_media_entries_supports_custom_download_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(twitter, "OUTPUT_DIR", str(tmp_path))
+    twitter.twitter_downloader.output_dir = str(tmp_path)
+
+    async def fake_download(url, filename, **_kwargs):
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"video")
+        return DownloadMetrics(
+            url=url,
+            path=str(path),
+            size=path.stat().st_size,
+            elapsed=0.01,
+            used_multipart=False,
+            resumed=False,
+        )
+
+    monkeypatch.setattr(twitter.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(twitter.twitter_downloader, "download", AsyncMock(side_effect=fake_download))
+
+    entries = await twitter._collect_media_entries(
+        "42",
+        {
+            "tweetURL": "https://x.com/user/status/42",
+            "media_extended": [{"type": "video", "url": "https://cdn.example.com/2.mp4"}],
+        },
+        download_dir_name="42_99_7",
+    )
+
+    assert len(entries) == 1
+    assert entries[0]["path"] == str(tmp_path / "42_99_7" / "2.mp4")
     monkeypatch.setattr(twitter, "OUTPUT_DIR", str(tmp_path))
     twitter.twitter_downloader.output_dir = str(tmp_path)
     get_file_id = AsyncMock(side_effect=["cached-photo-id", None])
@@ -303,6 +408,44 @@ async def test_inline_twitter_query_prefers_media_thumbnail(monkeypatch):
     results = query.answer.await_args.args[0]
     assert len(results) == 1
     assert results[0].thumbnail_url == "https://cdn.example.com/1.jpg"
+
+
+@pytest.mark.asyncio
+async def test_inline_twitter_query_single_media_skips_album_request(monkeypatch):
+    settings = {
+        "captions": "on",
+        "delete_message": "off",
+        "info_buttons": "on",
+        "url_button": "on",
+        "audio_button": "on",
+    }
+    query = SimpleNamespace(
+        from_user=SimpleNamespace(id=42),
+        chat_type="inline",
+        query="https://x.com/user/status/321",
+        answer=AsyncMock(),
+    )
+    tweet_media = {
+        "tweetURL": "https://x.com/user/status/321",
+        "text": "single video tweet",
+        "media_extended": [
+            {"type": "video", "url": "https://cdn.example.com/1.mp4", "thumbnail_url": "https://cdn.example.com/1.jpg"},
+        ],
+    }
+
+    monkeypatch.setattr(twitter, "send_analytics", AsyncMock())
+    monkeypatch.setattr(twitter.db, "user_settings", AsyncMock(return_value=settings))
+    monkeypatch.setattr(twitter, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(twitter, "_get_tweet_context", AsyncMock(return_value=("321", tweet_media)))
+    create_album_request = Mock(return_value="unused-token")
+    monkeypatch.setattr(twitter_inline, "create_inline_album_request", create_album_request)
+
+    await twitter.inline_twitter_query(query)
+
+    results = query.answer.await_args.args[0]
+    assert len(results) == 1
+    assert results[0].id.startswith("twitter_inline:")
+    create_album_request.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 import handlers
-from handlers import user
+from handlers import media_download, user
 from services.stats import chart
 
 
@@ -268,6 +268,39 @@ async def test_change_setting_rejects_invalid_callback_payload(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_change_setting_group_non_admin_is_denied(monkeypatch):
+    call = DummyCallback("setting:captions:on")
+    call.message.chat = SimpleNamespace(id=-100500, type="supergroup")
+    fake_db = SimpleNamespace(set_user_setting=AsyncMock(), get_user_setting=AsyncMock())
+    monkeypatch.setattr(user, "db", fake_db)
+    monkeypatch.setattr(user, "_is_group_admin", AsyncMock(return_value=False))
+
+    await user.change_setting(call)
+
+    call.answer.assert_awaited_once_with(user.bm.settings_admin_only(), show_alert=True)
+    fake_db.set_user_setting.assert_not_awaited()
+    call.message.edit_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_change_setting_group_admin_targets_chat(monkeypatch):
+    call = DummyCallback("setting:captions:on")
+    call.message.chat = SimpleNamespace(id=-100500, type="supergroup")
+    fake_db = SimpleNamespace(
+        upsert_chat=AsyncMock(),
+        set_user_setting=AsyncMock(),
+        get_user_setting=AsyncMock(return_value="on"),
+    )
+    monkeypatch.setattr(user, "db", fake_db)
+    monkeypatch.setattr(user, "_is_group_admin", AsyncMock(return_value=True))
+
+    await user.change_setting(call)
+
+    fake_db.set_user_setting.assert_awaited_once_with(user_id=-100500, field="captions", value="on")
+    call.message.edit_reply_markup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_change_setting_handles_invalid_db_setting_value(monkeypatch):
     call = DummyCallback("setting:captions:on")
     fake_db = SimpleNamespace(
@@ -423,11 +456,11 @@ async def test_process_batch_links_dispatches_each_supported_link(monkeypatch):
     message.answer = AsyncMock(side_effect=status_messages)
     process_supported_link = AsyncMock()
 
-    monkeypatch.setattr(user, "_process_supported_link", process_supported_link)
-    monkeypatch.setattr(user, "_resolve_batch_concurrency", lambda: 1)
-    monkeypatch.setattr(user, "send_analytics", AsyncMock())
-    monkeypatch.setattr(user, "update_info", AsyncMock())
-    monkeypatch.setattr(user.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(media_download, "_process_supported_link", process_supported_link)
+    monkeypatch.setattr(media_download, "_resolve_batch_concurrency", lambda: 1)
+    monkeypatch.setattr(media_download, "send_analytics", AsyncMock())
+    monkeypatch.setattr(media_download, "update_info", AsyncMock())
+    monkeypatch.setattr(media_download.asyncio, "sleep", AsyncMock())
 
     await user.process_batch_links(message)
 
@@ -451,11 +484,11 @@ async def test_process_batch_links_can_run_parallel_when_load_is_low(monkeypatch
     message.answer = AsyncMock(side_effect=status_messages)
     process_supported_link = AsyncMock()
 
-    monkeypatch.setattr(user, "_process_supported_link", process_supported_link)
-    monkeypatch.setattr(user, "_resolve_batch_concurrency", lambda: 2)
-    monkeypatch.setattr(user, "send_analytics", AsyncMock())
-    monkeypatch.setattr(user, "update_info", AsyncMock())
-    monkeypatch.setattr(user.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(media_download, "_process_supported_link", process_supported_link)
+    monkeypatch.setattr(media_download, "_resolve_batch_concurrency", lambda: 2)
+    monkeypatch.setattr(media_download, "send_analytics", AsyncMock())
+    monkeypatch.setattr(media_download, "update_info", AsyncMock())
+    monkeypatch.setattr(media_download.asyncio, "sleep", AsyncMock())
 
     await user.process_batch_links(message)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import itertools
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -9,7 +11,9 @@ import pytest
 from handlers import bot_profile_cache, telegram_ui_utils
 from handlers import utils
 from services.logger import summarize_text_for_log, summarize_url_for_log
+from utils import http_client
 from utils.download_manager import DownloadProgress, DownloadTooLargeError
+from utils.zip_utils import create_photos_zip
 import logging
 
 
@@ -565,3 +569,71 @@ def test_summarize_text_for_log_avoids_raw_text_echo():
 
     assert summary.startswith("text|len=")
     assert "private note" not in summary
+
+
+def test_create_photos_zip_stores_existing_files_without_recompression(tmp_path):
+    first = tmp_path / "a.jpg"
+    first.write_bytes(b"jpeg-bytes-1")
+    second = tmp_path / "b.png"
+    second.write_bytes(b"png-bytes-2")
+    missing = tmp_path / "missing.jpg"
+    zip_path = tmp_path / "out" / "photos.zip"
+
+    result = create_photos_zip([str(first), str(missing), str(second)], str(zip_path))
+
+    assert result == str(zip_path)
+    with zipfile.ZipFile(zip_path) as archive:
+        infos = archive.infolist()
+        assert [info.filename for info in infos] == ["photo_01.jpg", "photo_03.png"]
+        assert all(info.compress_type == zipfile.ZIP_STORED for info in infos)
+        assert archive.read("photo_01.jpg") == b"jpeg-bytes-1"
+        assert archive.read("photo_03.png") == b"png-bytes-2"
+
+
+def test_get_http_session_recreates_lock_and_session_after_loop_change(monkeypatch):
+    connectors = []
+
+    class DummyConnector:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            connectors.append(self)
+
+        def close(self):
+            async def _mark_closed():
+                self.closed = True
+
+            return _mark_closed()
+
+    class DummySession:
+        def __init__(self, *, timeout, connector):
+            self.timeout = timeout
+            self.connector = connector
+            self.closed = False
+            self.detached = False
+
+        def detach(self):
+            self.detached = True
+            self.closed = True
+            self.connector = None
+
+    monkeypatch.setattr(http_client.aiohttp, "TCPConnector", DummyConnector)
+    monkeypatch.setattr(http_client.aiohttp, "ClientSession", DummySession)
+    monkeypatch.setattr(http_client, "_session", None)
+    monkeypatch.setattr(http_client, "_session_loop", None)
+    monkeypatch.setattr(http_client, "_lock", asyncio.Lock())
+    monkeypatch.setattr(http_client, "_lock_loop", None)
+
+    first = asyncio.run(http_client.get_http_session())
+    lock_after_first = http_client._lock
+    second = asyncio.run(http_client.get_http_session())
+
+    assert second is not first
+    assert http_client._lock is not lock_after_first
+    # The old-loop session must be detached, never close()-awaited on the new loop.
+    assert first.detached is True
+    assert connectors[0].closed is True
+    assert second.closed is False
+
+    asyncio.run(http_client.close_http_session())
+    assert second.detached is True

--- a/tests/test_youtube_handler.py
+++ b/tests/test_youtube_handler.py
@@ -6,7 +6,7 @@ import pytest
 from handlers import youtube
 from services.inline.video_requests import create_inline_video_request, get_inline_video_request
 from tests.conftest import FakeYoutubeDL
-from utils.download_manager import DownloadMetrics
+from utils.download_manager import DownloadMetrics, DownloadRateLimitError
 
 
 def test_get_video_stream_prefers_progressive():
@@ -327,3 +327,88 @@ async def test_download_music_falls_back_to_ytdlp_without_direct_audio_stream(mo
     assert message.reply_audio.await_args.kwargs["duration"] == 204
     youtube.db.add_file.assert_awaited_once()
     prepared_metadata.cleanup.assert_called_once_with()
+
+
+def _make_mp3_callback(status_message):
+    return SimpleNamespace(
+        data="audio:youtube:abc123",
+        answer=AsyncMock(),
+        from_user=SimpleNamespace(id=7, username="tester"),
+        message=SimpleNamespace(
+            business_connection_id=None,
+            chat=SimpleNamespace(id=99, type="private"),
+            answer=AsyncMock(return_value=status_message),
+            reply_audio=AsyncMock(),
+            reply=AsyncMock(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_youtube_mp3_callback_removes_file_when_send_fails(monkeypatch, tmp_path):
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"audio")
+    metrics = DownloadMetrics(
+        url="https://www.youtube.com/watch?v=abc123",
+        path=str(audio_path),
+        size=audio_path.stat().st_size,
+        elapsed=0.1,
+        used_multipart=False,
+        resumed=False,
+    )
+    status_message = SimpleNamespace(delete=AsyncMock())
+    call = _make_mp3_callback(status_message)
+    yt = {
+        "id": "abc123",
+        "title": "Broken Audio",
+        "webpage_url": "https://www.youtube.com/watch?v=abc123",
+        "duration": 100,
+    }
+
+    monkeypatch.setattr(youtube, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(youtube, "get_bot_avatar_thumbnail", AsyncMock(return_value=None))
+    monkeypatch.setattr(youtube, "get_youtube_video", lambda _url: yt)
+    monkeypatch.setattr(youtube.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(youtube.db, "add_file", AsyncMock())
+    monkeypatch.setattr(youtube, "download_mp3_with_ytdlp_metrics", AsyncMock(return_value=metrics))
+    prepared_metadata = SimpleNamespace(thumbnail_path=None, cleanup=Mock())
+    monkeypatch.setattr(youtube, "prepare_mp3_metadata", AsyncMock(return_value=prepared_metadata))
+    monkeypatch.setattr(youtube, "send_audio_with_thumbnail", AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(youtube, "send_chat_action_if_needed", AsyncMock())
+    monkeypatch.setattr(youtube, "safe_edit_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(youtube, "safe_delete_message", AsyncMock())
+    monkeypatch.setattr(youtube, "remove_file", AsyncMock())
+    monkeypatch.setattr(youtube, "handle_download_error", AsyncMock())
+
+    await youtube.download_youtube_mp3_callback(call)
+
+    youtube.remove_file.assert_awaited_once_with(str(audio_path))
+    prepared_metadata.cleanup.assert_called_once_with()
+    youtube.handle_download_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_download_youtube_mp3_callback_reports_backpressure(monkeypatch):
+    status_message = SimpleNamespace(delete=AsyncMock())
+    call = _make_mp3_callback(status_message)
+    yt = {
+        "id": "abc123",
+        "title": "Rate Limited Audio",
+        "webpage_url": "https://www.youtube.com/watch?v=abc123",
+        "duration": 100,
+    }
+    rate_limit_error = DownloadRateLimitError(retry_after=30.0)
+
+    monkeypatch.setattr(youtube, "get_bot_url", AsyncMock(return_value="https://t.me/maxloadbot"))
+    monkeypatch.setattr(youtube, "get_bot_avatar_thumbnail", AsyncMock(return_value=None))
+    monkeypatch.setattr(youtube, "get_youtube_video", lambda _url: yt)
+    monkeypatch.setattr(youtube.db, "get_file_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(youtube, "retry_async_operation", AsyncMock(side_effect=rate_limit_error))
+    monkeypatch.setattr(youtube, "handle_download_backpressure_error", AsyncMock())
+    monkeypatch.setattr(youtube, "safe_edit_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(youtube, "safe_delete_message", AsyncMock())
+
+    await youtube.download_youtube_mp3_callback(call)
+
+    youtube.handle_download_backpressure_error.assert_awaited_once()
+    assert youtube.handle_download_backpressure_error.await_args.args[0] is rate_limit_error

--- a/tests/test_youtube_inline.py
+++ b/tests/test_youtube_inline.py
@@ -1,0 +1,172 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import messages as bm
+from handlers.deps import build_handler_dependencies
+from handlers.utils import build_queue_busy_text, build_rate_limit_text
+from handlers.youtube_inline import send_inline_youtube_music, send_inline_youtube_video
+from services.inline.video_requests import (
+    create_inline_video_request,
+    get_inline_video_request,
+)
+from utils.download_manager import DownloadQueueBusyError, DownloadRateLimitError
+
+SETTINGS = {
+    "captions": "on",
+    "delete_message": "off",
+    "info_buttons": "on",
+    "url_button": "on",
+    "audio_button": "on",
+}
+
+
+def _safe_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _make_deps(db=None):
+    return build_handler_dependencies(
+        bot=SimpleNamespace(send_video=AsyncMock(), send_audio=AsyncMock()),
+        db=db
+        or SimpleNamespace(
+            get_file_id=AsyncMock(return_value=None),
+            add_file=AsyncMock(),
+        ),
+        send_analytics=AsyncMock(),
+    )
+
+
+async def _run_send_inline_video(download_stream_fn):
+    token = create_inline_video_request(
+        "youtube",
+        "https://www.youtube.com/watch?v=abc123",
+        42,
+        dict(SETTINGS),
+    )
+    edit_inline_text = AsyncMock(return_value=True)
+    await send_inline_youtube_video(
+        token=token,
+        inline_message_id="inline-message-1",
+        actor_name="Inline User",
+        actor_user_id=42,
+        request_event_id="evt-1",
+        duplicate_handler="chosen",
+        deps=_make_deps(),
+        channel_id=-1001234,
+        max_file_size=2_000_000_000,
+        ytdlp_format_720="best",
+        get_youtube_video_fn=lambda url: {
+            "id": "abc123",
+            "title": "Video",
+            "webpage_url": url,
+            "view_count": 1,
+            "like_count": 1,
+        },
+        get_video_stream_fn=lambda _yt: {
+            "url": "https://cdn.example.com/v.mp4",
+            "filesize": 1024,
+        },
+        safe_int_fn=_safe_int,
+        is_manifest_stream_fn=lambda _video: False,
+        download_stream_fn=download_stream_fn,
+        download_with_ytdlp_metrics_fn=AsyncMock(return_value=None),
+        get_bot_url_fn=AsyncMock(return_value="https://t.me/maxloadbot"),
+        safe_edit_inline_media_fn=AsyncMock(return_value=True),
+        safe_edit_inline_text_fn=edit_inline_text,
+    )
+    return token, edit_inline_text
+
+
+@pytest.mark.asyncio
+async def test_send_inline_youtube_video_rate_limit_resets_request():
+    token, edits = await _run_send_inline_video(
+        AsyncMock(side_effect=DownloadRateLimitError(retry_after=30.0))
+    )
+
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "pending"
+    last_call = edits.await_args_list[-1]
+    assert last_call.args[2] == build_rate_limit_text(30.0)
+    assert last_call.kwargs["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_send_inline_youtube_video_queue_busy_resets_request():
+    token, edits = await _run_send_inline_video(
+        AsyncMock(side_effect=DownloadQueueBusyError(position=3))
+    )
+
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "pending"
+    last_call = edits.await_args_list[-1]
+    assert last_call.args[2] == build_queue_busy_text(3)
+    assert last_call.kwargs["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_send_inline_youtube_video_generic_error_resets_request():
+    token, edits = await _run_send_inline_video(
+        AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "pending"
+    last_call = edits.await_args_list[-1]
+    assert last_call.args[2] == bm.something_went_wrong()
+    assert last_call.kwargs["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_send_inline_youtube_music_generic_error_resets_request():
+    token = create_inline_video_request(
+        "youtube",
+        "https://music.youtube.com/watch?v=abc123",
+        42,
+        dict(SETTINGS),
+    )
+    deps = _make_deps(
+        db=SimpleNamespace(
+            get_file_id=AsyncMock(side_effect=RuntimeError("boom")),
+            add_file=AsyncMock(),
+        )
+    )
+    edit_inline_text = AsyncMock(return_value=True)
+
+    await send_inline_youtube_music(
+        token=token,
+        inline_message_id="inline-message-2",
+        actor_name="Inline User",
+        actor_user_id=42,
+        request_event_id="evt-2",
+        duplicate_handler="chosen",
+        deps=deps,
+        channel_id=-1001234,
+        max_file_size=2_000_000_000,
+        get_youtube_video_fn=lambda url: {
+            "id": "abc123",
+            "title": "Song",
+            "webpage_url": url,
+            "duration": 100,
+        },
+        download_mp3_with_ytdlp_metrics_fn=AsyncMock(return_value=None),
+        retry_async_operation_fn=AsyncMock(return_value=None),
+        get_bot_avatar_thumbnail_fn=AsyncMock(return_value=None),
+        get_bot_url_fn=AsyncMock(return_value="https://t.me/maxloadbot"),
+        safe_edit_inline_media_fn=AsyncMock(return_value=True),
+        safe_edit_inline_text_fn=edit_inline_text,
+    )
+
+    request = get_inline_video_request(token)
+    assert request is not None
+    assert request.state == "pending"
+    last_call = edit_inline_text.await_args_list[-1]
+    assert last_call.args[2] == bm.something_went_wrong()
+    assert last_call.kwargs["reply_markup"] is not None

--- a/utils/cobalt_media.py
+++ b/utils/cobalt_media.py
@@ -1,4 +1,8 @@
-from typing import Optional
+from typing import NamedTuple, Optional
+
+from services.logger import logger as logging
+
+logging = logging.bind(service="cobalt_media")
 
 
 def classify_cobalt_media_type(
@@ -36,3 +40,143 @@ def classify_cobalt_media_type(
     if any(ext in probe for ext in (".jpg", ".jpeg", ".png", ".webp", ".avif")):
         return "photo"
     return "video"
+
+
+def extract_cobalt_thumb(source: dict) -> Optional[str]:
+    for key in ("thumb", "thumbnail", "poster", "preview", "cover"):
+        value = source.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+class CobaltParsedMedia(NamedTuple):
+    """Resolved response status plus (url, media_type, thumb) tuples."""
+
+    status: str
+    items: list[tuple[str, str, Optional[str]]]
+
+
+def parse_cobalt_media_response(
+    data: dict,
+    *,
+    audio_only: bool = False,
+    allow_multi_tunnel: bool = False,
+    source: str = "cobalt",
+) -> Optional[CobaltParsedMedia]:
+    """Parse the Cobalt status machine into (url, type, thumb) media tuples.
+
+    Handles the tunnel/redirect, picker, local-processing and error statuses,
+    inferring a missing status from the payload shape. Returns None when the
+    response is an error, unsupported, or yields no media items.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    status = data.get("status")
+    if not status:
+        if "url" in data:
+            status = "tunnel"
+        elif "picker" in data:
+            status = "picker"
+
+    items: list[tuple[str, str, Optional[str]]] = []
+
+    if status in {"tunnel", "redirect"}:
+        media_url = data.get("url")
+        if isinstance(media_url, str) and media_url:
+            items.append(
+                (
+                    media_url,
+                    classify_cobalt_media_type(
+                        media_url,
+                        audio_only=audio_only,
+                        filename=data.get("filename"),
+                    ),
+                    extract_cobalt_thumb(data),
+                )
+            )
+    elif status == "picker":
+        picker_audio_url = data.get("audio")
+        if audio_only and isinstance(picker_audio_url, str) and picker_audio_url:
+            items.append((picker_audio_url, "audio", None))
+        else:
+            for item in data.get("picker") or []:
+                if not isinstance(item, dict):
+                    continue
+                media_url = item.get("url")
+                if not isinstance(media_url, str) or not media_url:
+                    continue
+                items.append(
+                    (
+                        media_url,
+                        classify_cobalt_media_type(
+                            media_url,
+                            audio_only=audio_only,
+                            declared_type=item.get("type"),
+                        ),
+                        extract_cobalt_thumb(item),
+                    )
+                )
+    elif status == "local-processing":
+        tunnel_urls = data.get("tunnel") or []
+        output = data.get("output") if isinstance(data.get("output"), dict) else {}
+        if not isinstance(tunnel_urls, list) or not tunnel_urls:
+            logging.error(
+                "Cobalt local-processing response has no tunnels: source=%s payload=%s",
+                source,
+                data,
+            )
+            return None
+        if not allow_multi_tunnel and not audio_only and len(tunnel_urls) > 1:
+            logging.error(
+                "Unsupported Cobalt local-processing payload: source=%s type=%s tunnel_count=%s",
+                source,
+                data.get("type"),
+                len(tunnel_urls),
+            )
+            return None
+        for media_url in tunnel_urls:
+            if not isinstance(media_url, str) or not media_url:
+                continue
+            items.append(
+                (
+                    media_url,
+                    classify_cobalt_media_type(
+                        media_url,
+                        audio_only=audio_only,
+                        declared_type=data.get("type"),
+                        filename=output.get("filename"),
+                        mime_type=output.get("type"),
+                    ),
+                    extract_cobalt_thumb(data) or extract_cobalt_thumb(output),
+                )
+            )
+    elif status == "error":
+        error_obj = data.get("error") or {}
+        logging.error(
+            "Cobalt API returned error: source=%s code=%s context=%s",
+            source,
+            error_obj.get("code") if isinstance(error_obj, dict) else None,
+            error_obj.get("context") if isinstance(error_obj, dict) else None,
+        )
+        return None
+    else:
+        logging.error(
+            "Unsupported Cobalt response status: source=%s status=%s payload=%s",
+            source,
+            status,
+            data,
+        )
+        return None
+
+    if not items:
+        logging.error(
+            "Cobalt response has no media items: source=%s status=%s payload=%s",
+            source,
+            status,
+            data,
+        )
+        return None
+
+    return CobaltParsedMedia(status=status, items=items)

--- a/utils/download_manager.py
+++ b/utils/download_manager.py
@@ -332,6 +332,11 @@ class ResilientDownloader:
                 shared_future.set_exception(exc)
             raise
         finally:
+            # If the leader task was cancelled the future was never resolved
+            # (CancelledError is not caught above); cancel it so joined
+            # duplicate requests are released instead of hanging forever.
+            if not shared_future.done():
+                shared_future.cancel()
             async with self._inflight_lock:
                 current = self._inflight_downloads.get(inflight_key)
                 if current is shared_future:
@@ -521,7 +526,7 @@ class ResilientDownloader:
 
             if self.config.allow_resume and os.path.exists(temp_path):
                 existing_size = os.path.getsize(temp_path)
-                if existing_size and supports_range:
+                if existing_size and supports_range and existing_size < total_size:
                     headers.setdefault("Range", f"bytes={existing_size}-")
                     resumed = True
                     logging.debug(
@@ -531,6 +536,20 @@ class ResilientDownloader:
                         existing_size,
                         total_size,
                     )
+                elif existing_size:
+                    # A .part at or beyond the reported total (or with an
+                    # unknown total) is likely a preallocated multipart
+                    # leftover full of zero-filled holes; resuming from its
+                    # EOF would deliver corrupt data, so restart clean.
+                    logging.debug(
+                        "Discarding stale partial download: url=%s path=%s size=%s total=%s",
+                        url,
+                        temp_path,
+                        existing_size,
+                        total_size,
+                    )
+                    os.remove(temp_path)
+                    existing_size = 0
 
             progress_state = _ProgressState(
                 total_bytes=max(0, total_size),
@@ -735,16 +754,31 @@ class ResilientDownloader:
     ) -> None:
         """Stream the full file sequentially."""
         backoff = self.config.retry_backoff
+        resume = "Range" in headers
         for attempt in range(1, self.config.max_retries + 2):
             client = self._get_session()
+            request_headers = dict(headers)
+            if resume:
+                # Recompute the offset from the real file size on every
+                # attempt: a retry after a mid-stream failure must continue
+                # from the actual end of file, not the original offset,
+                # otherwise the append re-duplicates already-written bytes.
+                resume_from = (
+                    os.path.getsize(target_path)
+                    if os.path.exists(target_path)
+                    else 0
+                )
+                request_headers["Range"] = f"bytes={resume_from}-"
+                if progress_state:
+                    progress_state.downloaded_bytes = resume_from
             try:
                 with client.stream(
                     "GET",
                     url,
-                    headers=dict(headers),
+                    headers=request_headers,
                 ) as response:
                     response.raise_for_status()
-                    if "Range" in headers:
+                    if resume:
                         if (
                             response.status_code != 206
                             or "content-range" not in response.headers
@@ -756,9 +790,7 @@ class ResilientDownloader:
                         content_length = response.headers.get("content-length") or "0"
                         if content_length.isdigit():
                             base = (
-                                progress_state.downloaded_bytes
-                                if "Range" in headers
-                                else 0
+                                progress_state.downloaded_bytes if resume else 0
                             )
                             progress_state.total_bytes = base + int(content_length)
                     if (
@@ -770,7 +802,7 @@ class ResilientDownloader:
                             progress_state.total_bytes, max_size_bytes
                         )
                     with open(
-                        target_path, "ab" if "Range" in headers else "wb"
+                        target_path, "ab" if resume else "wb"
                     ) as outfile:
                         for chunk in response.iter_bytes(
                             chunk_size=self.config.chunk_size

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -3,13 +3,46 @@ from typing import Optional
 
 import aiohttp
 
+from services.logger import logger as logging
+
 _session: Optional[aiohttp.ClientSession] = None
 _session_loop: Optional[asyncio.AbstractEventLoop] = None
 _lock = asyncio.Lock()
+_lock_loop: Optional[asyncio.AbstractEventLoop] = None
 
 # Slightly higher limits to speed up bursty handler traffic while keeping sockets bounded
 _CLIENT_TIMEOUT = aiohttp.ClientTimeout(total=20, connect=5, sock_read=20)
 _CONNECTOR_LIMIT = 128
+
+
+def _get_loop_bound_lock() -> asyncio.Lock:
+    """Return the module lock, recreating it when the running loop changes.
+
+    An asyncio.Lock binds to the loop that first awaits it, so reusing the old
+    instance after a loop change would raise RuntimeError and permanently break
+    the session-recreation path this module implements.
+    """
+    global _lock, _lock_loop
+    loop = asyncio.get_running_loop()
+    if _lock_loop is not loop:
+        _lock = asyncio.Lock()
+        _lock_loop = loop
+    return _lock
+
+
+async def _close_session_from_previous_loop(session: aiohttp.ClientSession) -> None:
+    """Best-effort cleanup for a session created on a different event loop.
+
+    Awaiting ``session.close()`` would touch the previous loop's connector, so
+    detach the session and close the connector directly instead.
+    """
+    try:
+        connector = session.connector
+        session.detach()
+        if connector is not None:
+            await connector.close()
+    except Exception as exc:
+        logging.debug("Discarding HTTP session from a previous event loop: error=%s", exc)
 
 
 async def get_http_session() -> aiohttp.ClientSession:
@@ -19,7 +52,7 @@ async def get_http_session() -> aiohttp.ClientSession:
     if _session and not _session.closed and _session_loop is loop:
         return _session
 
-    async with _lock:
+    async with _get_loop_bound_lock():
         if _session and not _session.closed and _session_loop is loop:
             return _session
 
@@ -33,16 +66,22 @@ async def get_http_session() -> aiohttp.ClientSession:
         _session = aiohttp.ClientSession(timeout=_CLIENT_TIMEOUT, connector=connector)
         _session_loop = loop
         if previous_session and not previous_session.closed:
-            await previous_session.close()
+            # An open previous session here means the loop changed, so awaiting
+            # its close() would run on the wrong loop.
+            await _close_session_from_previous_loop(previous_session)
     return _session
 
 
 async def close_http_session() -> None:
     """Close the shared session if it was created."""
     global _session, _session_loop
-    async with _lock:
+    async with _get_loop_bound_lock():
         session = _session
+        session_loop = _session_loop
         _session = None
         _session_loop = None
     if session and not session.closed:
-        await session.close()
+        if session_loop is asyncio.get_running_loop():
+            await session.close()
+        else:
+            await _close_session_from_previous_loop(session)

--- a/utils/zip_utils.py
+++ b/utils/zip_utils.py
@@ -3,9 +3,13 @@ import zipfile
 
 
 def create_photos_zip(photo_paths: list[str], output_zip_path: str) -> str:
-    """Pack a list of local file paths into a single zip archive."""
+    """Pack a list of local file paths into a single zip archive.
+
+    Blocking: run via ``asyncio.to_thread`` when calling from async code.
+    Uses ZIP_STORED because photos are already compressed and do not deflate.
+    """
     os.makedirs(os.path.dirname(output_zip_path), exist_ok=True)
-    with zipfile.ZipFile(output_zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+    with zipfile.ZipFile(output_zip_path, "w", zipfile.ZIP_STORED) as zipf:
         for idx, path in enumerate(photo_paths, 1):
             if os.path.isfile(path):
                 ext = os.path.splitext(path)[1] or ".jpg"


### PR DESCRIPTION
## Summary

A full-codebase audit (16 review agents over every subsystem, 149 raw findings, 57 surviving adversarial verification) applied in two waves: targeted fixes first, then large deduplication refactors — with the full test suite, ruff, and the CI coverage gate green after every stage.

### Bug fixes & robustness
- **Download resume corruption**: the `Range` header is now recomputed from the actual file size on every retry attempt (previously a mid-stream retry re-fetched from the original offset and appended duplicate bytes); preallocated multipart `.part` files are discarded instead of resumed as zero-filled media
- **YouTube inline stuck state**: only `TimeoutError` was caught, so rate-limit/queue-busy/Telegram errors stranded the request token in `processing` for 6 hours; all five platforms now share one canonical error tail
- **Admin mailing**: banned users are excluded (the audience preview already excluded them); Telegram error-text matching fixed (`Telegram server says - ` prefix)
- **Middlewares**: instantiated once and shared across message/callback/inline registration — antiflood/ban state no longer fragments 3-way
- Download queue: idle per-user scope state is pruned (unbounded growth); a cancelled leading download releases joined duplicate requests
- Worker subprocess no longer pollutes the stderr error protocol nor races the parent's log rotation; third-party loggers route through app handlers
- TikTok: per-user settings in the `doc:` callback, per-URL locks for short-URL expansion, mojibake reaction emoji fixed
- CI: the nightly yt-dlp auto-bump workflow baseline could never pass — fixed

### Performance
- Moved blocking work off the event loop: ZIP compression, inline-request JSON persistence, admin filesystem walks/cleanup, PIL/ffmpeg avatar normalization, per-video `ffprobe` (now parallel) 
- TikTok photo sets: parallel downloads + batched cache lookups
- Migration `20260726_000010`: drops redundant secondary indexes on `analytics_events` (hottest insert table)

### Deduplication / structure
- `services/inline/send_flow.py` — shared inline delivery flow (query handling, cached photo/video delivery, album previews, error tail) for all five `*_inline.py` modules (~640 duplicated lines removed; `pinterest_inline.py` went 423 → 88 lines)
- `services/media/audio_flow.py` — shared MP3 pipeline, previously copy-pasted 6× across youtube/youtube_inline/soundcloud/spotify
- `CobaltMediaService` base + shared Cobalt response parsing in `utils/cobalt_media.py`
- `services/platforms/ytdlp_helpers.py` — shared yt-dlp scaffolding for the TikTok mixin and YouTube service
- `register_inline_send_handlers` — one registration factory replaces 8 copy-pasted `chosen_inline_result`/callback handler pairs; canonical `PermissionError`/`ValueError` mapping replaces 7 diverging try/except blocks
- Pinterest/Threads single-media and media-group flows merged; logging decorators collapsed into a factory; ~11 dead repository methods removed

Net source churn is ~zero (+3172/−3142 in src) — the new shared modules fit inside the removed duplication. Tests grew by +2333 lines.

## Verification
- `pytest`: **518 passed, 6 skipped** (DB-integration tests run in CI against Postgres) — up from 470; ~50 new tests cover the fixed bugs and shared flows
- Coverage **80.9%** (was 77.3%, CI gate 74%)
- `ruff check --select=E,F,W --ignore=E501 .` and `python -m compileall -q .` clean
- Public handler/service entry-point names and signatures preserved throughout (thin wrappers where bodies moved)

Known follow-ups (deliberately out of scope): port `handlers/instagram.py`'s media-group flow to `run_media_group_flow`, port threads/pinterest/twitter message-flow send closures to `make_video_or_document_senders`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)